### PR TITLE
Release 2.2.0 (align npm + PyPI)

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "captcha-kraken-js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "captcha-kraken-js",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captchakraken",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Browser-agnostic Playwright/Puppeteer captcha solver. Detects the captcha, reads the grid with a fine-tuned Qwen3.5-9B vision model on vLLM, and clicks through to a token.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "captchakraken"
-version = "2.0.0"
+version = "2.2.0"
 description = "Self-hosted captcha solver: OpenCV grid detection + a fine-tuned Qwen3.5-9B vision LoRA served on vLLM."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps both ports to **2.2.0** so npm (2.1.0) and PyPI (2.0.0) are consistent going forward, and exercises trusted publishing on merge (publish.yml auto-publishes both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)