### PR TITLE
Hosted-API attribution headers and credentials-file auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e . 'pytest>=7.0.0'
       - name: Hermetic no-regression suite
-        # The pre-deploy guard: grid detection (foundation of every solve), the
-        # stale-frame freshness check, and the unified fetch command.
-        run: |
-          python -m pytest -q \
-            tests/test_grid_detection_ci.py \
-            tests/test_freshness_check.py \
-            tests/test_fetch_command.py \
-            tests/test_pixel_parser.py
+        # The whole suite, not a hand-picked list. The previous four-file
+        # allowlist silently skipped test_solver.py, test_selected_fields.py,
+        # test_checkbox_captcha.py, test_move_indicator.py and
+        # test_object_detection.py — tests that existed, passed locally, and
+        # gated nothing. If a test is too slow or non-hermetic for CI, mark it
+        # (`@pytest.mark.skipif`) so the skip is visible in the run output
+        # rather than invisible in this file.
+        run: python -m pytest -q
 
   js-build:
     name: Solver build (TypeScript)

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ run_full_record.out
 run_full_record.sh
 *_video_attempt_*.png
 captcha_videos/
+# Personal VSCode workspace files (machine-specific; belong at a project
+# root, not in the tree). One strayed into python/tests/.
+*.code-workspace

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -17,7 +17,7 @@ import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { CaptchaKrakenConfig, SolverResult, ClickAction, CaptchaAction, SolveResult, CliResponse, TokenUsage, Vector, SolveStepEvent } from './types';
 import { aggregateTokenUsage } from './token-usage';
 
@@ -50,13 +50,16 @@ function getVenvPython(cliRoot: string): string | null {
 
 // Env for spawning the python CLI. Prepend the bundled `python/src` to
 // PYTHONPATH so `python -m captchakraken.cli` imports even when the postinstall
-// `pip install` was skipped or failed (best-effort bootstrap).
-function cliEnv(cliRoot: string): NodeJS.ProcessEnv {
+// `pip install` was skipped or failed (best-effort bootstrap). `extra` carries
+// per-invocation values (currently the solve session id) and is applied last so
+// it wins over the inherited environment.
+function cliEnv(cliRoot: string, extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const srcDir = path.join(cliRoot, 'src');
   const existing = process.env.PYTHONPATH;
   return {
     ...process.env,
     PYTHONPATH: existing ? `${srcDir}${path.delimiter}${existing}` : srcDir,
+    ...extra,
   };
 }
 
@@ -150,6 +153,12 @@ export class CaptchaKrakenSolver {
   // itself is never screenshotted and mis-read as a blank/unsupported frame.
   // Cleared once consumed. See solveSingle().
   private lastSubmitFrameHash: string | null = null;
+  // Groups every inference round of ONE captcha into a single attempt for the
+  // hosted API. A dynamic reCAPTCHA 3x3 re-solves after each click round, so one
+  // solve() can fire up to `recaptchaMaxDynamicRounds` model calls; sharing a
+  // session id lets the gateway bill them as one capped attempt rather than N
+  // independent ones. Null outside a solve; ignored entirely when self-hosting.
+  private solveSessionId: string | null = null;
 
   constructor(config: CaptchaKrakenConfig = {}) {
     this.config = config;
@@ -157,6 +166,7 @@ export class CaptchaKrakenSolver {
   }
 
   async solve(page: Page): Promise<SolveResult | void> {
+    this.solveSessionId = randomUUID();
     try {
       return await this.solveImpl(page);
     } finally {
@@ -164,6 +174,9 @@ export class CaptchaKrakenSolver {
       // failure, or timeout) so we never leak a python process between solves.
       this.teardownCvWorker();
       this.cvWorkerReady = null;
+      // Clear last: a stale id leaking into the NEXT solve would merge two
+      // separate captchas into one billable attempt.
+      this.solveSessionId = null;
     }
   }
 
@@ -1891,7 +1904,10 @@ export class CaptchaKrakenSolver {
     try {
       const { stdout, stderr } = await execAsync(command, {
         cwd: cliRoot,
-        env: cliEnv(cliRoot),
+        // Only this call reaches the model, so it's the only one that needs the
+        // session id — the other cliEnv() call sites run pure-OpenCV subcommands
+        // that never touch the inference endpoint.
+        env: cliEnv(cliRoot, this.solveSessionId ? { CAPTCHA_KRAKEN_SESSION: this.solveSessionId } : undefined),
         maxBuffer: 10 * 1024 * 1024 // Increase buffer for large outputs if needed
       });
 

--- a/python/src/captchakraken/config.py
+++ b/python/src/captchakraken/config.py
@@ -51,8 +51,60 @@ def base_url() -> str:
     return os.getenv("VLLM_BASE_URL", f"http://localhost:{port()}/v1")
 
 
+def state_dir() -> Path:
+    """Shared state dir for the pidfile, lockfile, server log, and credentials."""
+    return Path(os.getenv("CAPTCHA_KRAKEN_STATE_DIR", str(Path.home() / ".captchakraken")))
+
+
+def credentials_path() -> Path:
+    return state_dir() / "credentials"
+
+
+def _key_from_credentials_file() -> str:
+    """Key written by the MCP server's signup flow (or a future `login` command).
+
+    Hosted-API onboarding writes the key to a 0600 file rather than returning it
+    through the agent transcript, so it never lands in an LLM context window.
+    Reading it here is what lets a solve authenticate with NO env vars set.
+
+    Deliberately tolerant of a bare token, an env-file line, or surrounding
+    quotes: the file is written by a *separate* tool, and a format mismatch here
+    would surface as a baffling 401 rather than an obvious parse error.
+    Returns "" whenever the file is missing, unreadable, or has no usable line.
+    """
+    try:
+        text = credentials_path().read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            name, _, value = line.partition("=")
+            # An env-file with unrelated keys must not yield a bogus token.
+            if name.strip() not in {"CAPTCHA_KRAKEN_API_KEY", "VLLM_API_KEY"}:
+                continue
+            line = value.strip()
+        return line.strip("'\"")
+
+    return ""
+
+
 def api_key() -> str:
-    return os.getenv("CAPTCHA_KRAKEN_API_KEY") or os.getenv("VLLM_API_KEY") or "EMPTY"
+    """Bearer token, in precedence order.
+
+    Env first so an explicit override always wins, then the credentials file so
+    the MCP/hosted path needs no env plumbing at all, then "EMPTY" (which leaves
+    a self-hosted local vLLM open, as before).
+    """
+    return (
+        os.getenv("CAPTCHA_KRAKEN_API_KEY")
+        or os.getenv("VLLM_API_KEY")
+        or _key_from_credentials_file()
+        or "EMPTY"
+    )
 
 
 # ── Model identity (all overridable — the CLI itself is model-agnostic) ──────

--- a/python/src/captchakraken/config.py
+++ b/python/src/captchakraken/config.py
@@ -13,12 +13,36 @@ The two variables MOST users ever set:
 Advanced / self-hosting overrides (only needed to change WHICH model is served):
   CAPTCHA_BASE_MODEL      base weights vLLM loads         (HF id or local path)
   CAPTCHA_LORA_ADAPTER    LoRA applied on top             (HF id or local path)
+  CAPTCHA_LORA_REVISION   adapter git revision to serve
   CAPTCHA_LORA_NAME       served adapter name the client asks for as `model`
+
+Defaults for the model-identity values come from `pinned_model.json` (see
+`pinned()`), which records the model + prompt pair this release was validated
+against.
   VLLM_PORT, VLLM_GPU_MEMORY_UTILIZATION, VLLM_MAX_MODEL_LEN, VLLM_MAX_LORA_RANK
   CAPTCHA_KRAKEN_AUTOSTART=0   disable auto-starting a local server on first use
 """
 
+import json
 import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+_PINNED_MODEL_PATH = Path(__file__).with_name("pinned_model.json")
+
+
+@lru_cache(maxsize=1)
+def pinned() -> Dict[str, Any]:
+    """The pinned model manifest shipped with this release.
+
+    Defines the (base model, adapter, serving prompts) triple this version was
+    validated against. Env vars still override every value below — the manifest
+    supplies the DEFAULT and gives CI something to assert against, so an adapter
+    or prompt change is a reviewable diff instead of a silent drift.
+    """
+    with _PINNED_MODEL_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
 
 
 # ── Inference endpoint ──────────────────────────────────────────────────────
@@ -33,17 +57,23 @@ def api_key() -> str:
 
 # ── Model identity (all overridable — the CLI itself is model-agnostic) ──────
 def base_model() -> str:
-    return os.getenv("CAPTCHA_BASE_MODEL", "Qwen/Qwen3.5-9B")
+    return os.getenv("CAPTCHA_BASE_MODEL", pinned()["base_model"])
 
 
 def lora_adapter() -> str:
     """HF repo id or local path of the captcha adapter served on top of the base."""
-    return os.getenv("CAPTCHA_LORA_ADAPTER", "CaptchaKraken/CaptchaKraken_v1")
+    return os.getenv("CAPTCHA_LORA_ADAPTER", pinned()["lora_adapter"])
+
+
+def lora_revision() -> str:
+    """Git revision of the adapter repo to serve — pinning this is what makes
+    'the adapter this release was tested against' a reproducible statement."""
+    return os.getenv("CAPTCHA_LORA_REVISION", pinned()["lora_revision"])
 
 
 def lora_name() -> str:
     """The served LoRA name the client sends as the `model` field."""
-    return os.getenv("CAPTCHA_LORA_NAME", "captcha")
+    return os.getenv("CAPTCHA_LORA_NAME", pinned()["lora_name"])
 
 
 # ── Local vLLM server knobs ─────────────────────────────────────────────────

--- a/python/src/captchakraken/pinned_model.json
+++ b/python/src/captchakraken/pinned_model.json
@@ -1,0 +1,28 @@
+{
+  "_comment": [
+    "The model this release of CaptchaKraken is PINNED to, plus the prompts it",
+    "was trained to answer. CI reads this file; see tests/test_pinned_model.py.",
+    "",
+    "Why a file and not just env defaults: the adapter and the serving prompts",
+    "are a matched pair. On 2026-07-18 the LoRA was retrained on the content",
+    "schema (action: drag / drags[] / lowercase) while planner.py still asked",
+    "for the legacy output/PascalCase schema. The model answered in a hybrid,",
+    "the parser dropped it, and EVERY drag puzzle failed as 'unsupported' with",
+    "no test going red. Recording the prompt hashes here means any edit to a",
+    "serving prompt fails CI until someone consciously re-pins — which forces",
+    "the question 'does the pinned adapter still expect this prompt?'.",
+    "",
+    "To ship a new adapter: update lora_adapter/lora_revision, re-run the Tier 2",
+    "static-image gate against it, and update prompt_sha256 if the prompts moved."
+  ],
+
+  "base_model": "RedHatAI/Qwen3.5-9B-FP8-dynamic",
+  "lora_adapter": "CaptchaKraken/CaptchaKraken_v1.1",
+  "lora_revision": "main",
+  "lora_name": "captcha",
+
+  "prompt_sha256": {
+    "PIXEL_ACTION_PROMPT": "15d4833135330aa57ec64eb9132d15739cbf4a10bcda2e6d85d2d0ad92e0216a",
+    "SELECT_GRID_PROMPT": "f014dbc1cb8c773cc9501ff97aea92ff0281e5687b3d637d1c626ded9212fd3c"
+  }
+}

--- a/python/src/captchakraken/planner.py
+++ b/python/src/captchakraken/planner.py
@@ -23,6 +23,38 @@ from .timing import timed
 
 DEBUG = os.getenv("CAPTCHA_DEBUG", "0") == "1"
 
+# Header the fleet's haproxy front (on the reverse-proxy EC2) routes on. When a
+# caller sets CAPTCHA_REQUEST_PRIORITY to a positive int, every request carries
+# `X-JH-Priority: <n>`; haproxy sends anything above its threshold (5) straight
+# to the backup GPUs so it never competes with production traffic on the main
+# 5090. The tier-2 CI gate sets this — its traffic is throwaway and must stay
+# off the primary.
+#
+# Deliberately a HEADER, not vLLM's request-body `priority` field: that field is
+# lower-is-higher and already means captcha=0 / apply=100 / label=200 on the
+# priority-scheduled primary, so a value like 10 would MISORDER there (it would
+# outrank apply/label). Routing is a fleet concern, kept out of the model's
+# scheduler.
+_PRIORITY_HEADER = "X-JH-Priority"
+_PRIORITY_ENV = "CAPTCHA_REQUEST_PRIORITY"
+
+
+def routing_headers(env=None) -> Dict[str, str]:
+    """Fleet-routing headers derived from the environment (empty by default).
+
+    Split out and env-injectable so it can be unit-tested without a live server.
+    A missing or non-integer CAPTCHA_REQUEST_PRIORITY yields no header at all —
+    an unset/garbage value must never silently tag traffic for the backups.
+    """
+    env = os.environ if env is None else env
+    raw = (env.get(_PRIORITY_ENV) or "").strip()
+    if not raw:
+        return {}
+    try:
+        return {_PRIORITY_HEADER: str(int(raw))}
+    except ValueError:
+        return {}
+
 
 # Matches the training-distribution grid prompts in
 # cleanSamples/test/test_solutions.json -> grade.synthesize_instruction.
@@ -129,6 +161,10 @@ class ActionPlanner:
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
+            # Fleet routing: absent unless CAPTCHA_REQUEST_PRIORITY is set (see
+            # routing_headers). Low-priority batch traffic is steered to the
+            # backup GPUs by the haproxy front on this header.
+            **routing_headers(),
         }
 
         # Hands-off server: before the very first request, make sure something
@@ -290,12 +326,31 @@ class ActionPlanner:
                   "including any matches you may have overlooked."
             )
         raw = self._chat_with_image(prompt, image_path, max_tokens=128)
-        data = self._parse_json(raw)
+        out = self._normalize_grid(self._parse_json(raw), total)
+        self._log(f"grid selection -> {out}")
+        return out
 
+    @staticmethod
+    def _normalize_grid(data: Any, total: int) -> List[int]:
+        """Map the model's grid JSON to a list of 1-indexed cell numbers.
+
+        Accepts the trained shape (a bare JSON array) plus the wrapped forms the
+        model drifts into: {"target_ids": [...]} and {"action": {"target_ids":
+        [...]}}. Out-of-range and non-numeric entries are dropped rather than
+        raising — a single junk element must not cost the whole selection.
+
+        Split out of get_grid_selection so the parse is testable without a
+        model, mirroring _normalize_pixel.
+        """
         if isinstance(data, list):
             ids = data
         elif isinstance(data, dict):
-            ids = data.get("target_ids") or data.get("action", {}).get("target_ids") or []
+            # `action` is a dict on the grid path but a bare string ("drag") on
+            # the pixel path — guard so a mis-routed response returns [] rather
+            # than raising AttributeError.
+            nested = data.get("action")
+            nested_ids = nested.get("target_ids") if isinstance(nested, dict) else None
+            ids = data.get("target_ids") or nested_ids or []
         else:
             ids = []
 
@@ -303,11 +358,10 @@ class ActionPlanner:
         for v in ids:
             try:
                 iv = int(v)
-                if 1 <= iv <= total:
-                    out.append(iv)
             except (TypeError, ValueError):
                 continue
-        self._log(f"grid selection -> {out}")
+            if 1 <= iv <= total:
+                out.append(iv)
         return out
 
     def get_pixel_actions(self, image_path: str) -> List[Dict[str, Any]]:

--- a/python/src/captchakraken/planner.py
+++ b/python/src/captchakraken/planner.py
@@ -38,22 +38,62 @@ DEBUG = os.getenv("CAPTCHA_DEBUG", "0") == "1"
 _PRIORITY_HEADER = "X-JH-Priority"
 _PRIORITY_ENV = "CAPTCHA_REQUEST_PRIORITY"
 
+# Hosted-API metadata. Both are OPTIONAL and absent unless deliberately set, so
+# self-hosted users never send them and are unaffected.
+#
+# X-CK-Client  — which integration issued this solve (e.g. "camoufox/0.4.11").
+#   camoufox sets CAPTCHA_KRAKEN_CLIENT in the env it spawns the solver with, so
+#   the gateway can account camoufox-attributed usage separately. Attribution
+#   ONLY: it is caller-supplied and therefore never priced on (the gateway
+#   derives billable puzzle class from the request body instead).
+# X-CK-Session — groups the 1..N inference rounds of ONE captcha into a single
+#   billable attempt. The JS driver mints a UUID per solve() and reuses it for
+#   every CLI invocation in that solve, which is what lets the gateway cap an
+#   attempt's billable rounds instead of charging per round without limit.
+_CLIENT_HEADER = "X-CK-Client"
+_CLIENT_ENV = "CAPTCHA_KRAKEN_CLIENT"
+_SESSION_HEADER = "X-CK-Session"
+_SESSION_ENV = "CAPTCHA_KRAKEN_SESSION"
+
+# These values reach the wire verbatim from the environment, so they are
+# sanitized rather than trusted: a CR/LF would otherwise splice arbitrary
+# headers into the upstream request.
+_HEADER_VALUE_MAX = 128
+
+
+def _clean_header_value(raw: str) -> str:
+    """Printable-ASCII, length-capped header value ("" when nothing survives)."""
+    return "".join(c for c in raw.strip() if 0x20 <= ord(c) < 0x7F)[:_HEADER_VALUE_MAX]
+
 
 def routing_headers(env=None) -> Dict[str, str]:
-    """Fleet-routing headers derived from the environment (empty by default).
+    """Fleet-routing + hosted-API headers derived from the environment.
 
-    Split out and env-injectable so it can be unit-tested without a live server.
-    A missing or non-integer CAPTCHA_REQUEST_PRIORITY yields no header at all —
-    an unset/garbage value must never silently tag traffic for the backups.
+    Empty by default. Split out and env-injectable so it can be unit-tested
+    without a live server. A missing or non-integer CAPTCHA_REQUEST_PRIORITY
+    yields no header at all — an unset/garbage value must never silently tag
+    traffic for the backups.
+
+    Each header is derived independently: a malformed priority must not suppress
+    the attribution headers, or one typo would silently make a camoufox solve
+    look like direct traffic and understate the partner's revenue share.
     """
     env = os.environ if env is None else env
+    headers: Dict[str, str] = {}
+
     raw = (env.get(_PRIORITY_ENV) or "").strip()
-    if not raw:
-        return {}
-    try:
-        return {_PRIORITY_HEADER: str(int(raw))}
-    except ValueError:
-        return {}
+    if raw:
+        try:
+            headers[_PRIORITY_HEADER] = str(int(raw))
+        except ValueError:
+            pass
+
+    for header, var in ((_CLIENT_HEADER, _CLIENT_ENV), (_SESSION_HEADER, _SESSION_ENV)):
+        value = _clean_header_value(env.get(var) or "")
+        if value:
+            headers[header] = value
+
+    return headers
 
 
 # Matches the training-distribution grid prompts in

--- a/python/src/captchakraken/planner.py
+++ b/python/src/captchakraken/planner.py
@@ -46,21 +46,21 @@ PIXEL_ACTION_PROMPT = (
     "Your task is to solve the captcha. Read the instruction at the top of the image carefully.\n\n"
     "Look at the puzzle and decide what action solves it. All coordinates you return must be on a "
     "normalized 0–1000 image scale (top-left = (0, 0), bottom-right = (1000, 1000)).\n\n"
+    "Name WHAT each object is with a short 1–2 word label, then give its position. "
     "Choose ONE response:\n\n"
     "FOR CLICK PUZZLES:\n"
-    "  Identify every position you need to click and emit them as a list of points:\n"
-    "  → \"action\": { \"action\": \"click\", \"points\": [[x1, y1], [x2, y2], ...] }\n\n"
+    "  Label each thing you click and give its point — subjects[i] names points[i]:\n"
+    "  → \"action\": \"click\", \"subjects\": [\"<label>\", ...], "
+    "\"points\": [[x1, y1], [x2, y2], ...]\n\n"
     "FOR DRAG PUZZLES:\n"
-    "  Drag ONE item at a time. The source position is the centroid of the piece you are picking up; "
-    "the destination position is where it should end up. If multiple drags are needed, drag the topmost "
-    "item first.\n"
-    "  → \"output\": [{ \"Action\": \"simulate_drag\", "
-    "\"SourceDescription\": \"...\", \"SourcePosition\": { \"x\": 1-1000, \"y\": 1-1000 }, "
-    "\"DestinationDescription\": \"...\", \"EstimatedPosition\": { \"x\": 1-1000, \"y\": 1-1000 } }]\n\n"
+    "  Drag ONE item at a time. Label the source (the piece you pick up) and the destination "
+    "(where it belongs), each with a short 1–2 word label, and give both points:\n"
+    "  → \"action\": \"drag\", \"drags\": [{ \"source\": \"<label>\", \"from\": [x, y], "
+    "\"destination\": \"<label>\", \"to\": [x, y] }, ...]\n\n"
     "Respond ONLY with JSON:\n"
     "{\n"
-    "  \"action\": { ... }\n"
-    "  // OR \"output\": [ ... ]\n"
+    "  \"action\": \"click\", \"subjects\": [ ... ], \"points\": [ ... ]\n"
+    "  // OR \"action\": \"drag\", \"drags\": [ ... ]\n"
     "}"
 )
 
@@ -394,6 +394,31 @@ class ActionPlanner:
         out: List[Dict[str, Any]] = []
         if not isinstance(data, dict):
             return out
+
+        # ---- drag (CANONICAL — the schema PIXEL_ACTION_PROMPT asks for and the
+        #      LoRA is trained on, see instructions.py::ACTION_INSTRUCTION):
+        #      {"action":"drag","drags":[{"source","from":[x,y],"destination","to":[x,y]}]}
+        # Note "action" here is the STRING "drag", not a dict, so the click path
+        # below never sees it. The legacy/simulate_drag branches that follow stay
+        # as fallbacks for older adapters.
+        content_drags = data.get("drags")
+        if content_drags is None and isinstance(data.get("action"), dict):
+            content_drags = data["action"].get("drags")
+        if isinstance(content_drags, dict):
+            content_drags = [content_drags]
+        if isinstance(content_drags, list) and content_drags:
+            for d in content_drags:
+                if not isinstance(d, dict):
+                    continue
+                snums = flat_numbers(d.get("from"))
+                dnums = flat_numbers(d.get("to"))
+                if len(snums) >= 2 and len(dnums) >= 2:
+                    src = norm_xy(snums[0], snums[1])
+                    dst = norm_xy(dnums[0], dnums[1])
+                    if src and dst:
+                        out.append({"kind": "drag", "src": src, "dst": dst})
+            if out:
+                return out
 
         # ---- drag: {"output": [ {simulate_drag ...}, ... ]} ----
         drags = data.get("output")

--- a/python/src/captchakraken/server_manager.py
+++ b/python/src/captchakraken/server_manager.py
@@ -29,8 +29,9 @@ import requests
 
 from . import config
 
-# One shared state dir for the pidfile, lockfile, and server log.
-STATE_DIR = Path(os.getenv("CAPTCHA_KRAKEN_STATE_DIR", str(Path.home() / ".captchakraken")))
+# One shared state dir for the pidfile, lockfile, server log, and the hosted-API
+# credentials file. Defined in `config` so the path has a single definition.
+STATE_DIR = config.state_dir()
 LOCK_FILE = STATE_DIR / "vllm.lock"
 PID_FILE = STATE_DIR / "vllm.pid"
 LOG_FILE = STATE_DIR / "vllm.log"

--- a/python/tests/test_checkbox_captcha.py
+++ b/python/tests/test_checkbox_captcha.py
@@ -6,6 +6,14 @@ import sys
 # Add src to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
+# DEAD SINCE THE MONOREPO RESTRUCTURE (529f144). `attention` was a v1-architecture
+# module; v1 is preserved on the `v1-old-architecture` branch and this module does
+# not exist here, so this file has been uncollectable — it did not fail CI only
+# because CI ran a four-file allowlist. Skipping visibly instead of silently
+# ignoring it. Either port these to the v2 planner or delete the file; a test that
+# can never run is not coverage.
+pytest.importorskip("attention", reason="v1-only module; see comment above")
+
 from attention import AttentionExtractor
 
 # Paths

--- a/python/tests/test_credentials_file.py
+++ b/python/tests/test_credentials_file.py
@@ -1,0 +1,87 @@
+"""Tests for the hosted-API credentials-file fallback in `config.api_key()`.
+
+The MCP signup flow writes the account key to a 0600 file under the state dir
+instead of returning it through the agent transcript, so the key never lands in
+an LLM context window. `api_key()` reading that file is what lets a solve
+authenticate with NO env vars set at all.
+
+Two boundaries carry real consequences and are pinned here:
+  * env must still win, or an explicit override would be silently ignored;
+  * a missing/garbage file must degrade to "EMPTY" exactly as before, or every
+    self-hosted user without the file breaks.
+
+Hermetic: no network, no server. `CAPTCHA_KRAKEN_STATE_DIR` is redirected at a
+tmp_path so a developer's real ~/.captchakraken is never read or written.
+"""
+import pytest
+
+from captchakraken import config
+
+
+@pytest.fixture
+def creds(tmp_path, monkeypatch):
+    """Redirect the state dir to tmp and clear both key env vars.
+
+    Returns a writer so each test states only the file contents it cares about.
+    """
+    monkeypatch.setenv("CAPTCHA_KRAKEN_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("CAPTCHA_KRAKEN_API_KEY", raising=False)
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+
+    def write(text: str):
+        (tmp_path / "credentials").write_text(text, encoding="utf-8")
+
+    return write
+
+
+def test_no_file_still_yields_empty(creds):
+    # The self-hosted default. Must not raise, must not change behaviour.
+    assert config.api_key() == "EMPTY"
+
+
+def test_bare_token_is_read(creds):
+    creds("ck_live_abc123\n")
+    assert config.api_key() == "ck_live_abc123"
+
+
+def test_env_file_form_is_read(creds):
+    # The MCP server may write a sourceable env file rather than a bare token.
+    creds("CAPTCHA_KRAKEN_API_KEY=ck_live_abc123\n")
+    assert config.api_key() == "ck_live_abc123"
+
+
+def test_quotes_and_comments_are_tolerated(creds):
+    creds('# written by @captchakraken/mcp\n\nCAPTCHA_KRAKEN_API_KEY="ck_live_xyz"\n')
+    assert config.api_key() == "ck_live_xyz"
+
+
+def test_unrelated_env_keys_do_not_yield_a_bogus_token(creds):
+    # Picking up the RHS of some unrelated line would send garbage as a bearer
+    # token and surface as a confusing 401.
+    creds("VLLM_BASE_URL=https://api.captchakraken.com/v1\n")
+    assert config.api_key() == "EMPTY"
+
+
+def test_explicit_env_wins_over_the_file(creds, monkeypatch):
+    creds("ck_live_from_file\n")
+    monkeypatch.setenv("CAPTCHA_KRAKEN_API_KEY", "ck_live_from_env")
+    assert config.api_key() == "ck_live_from_env"
+
+
+def test_vllm_api_key_still_wins_over_the_file(creds, monkeypatch):
+    # Pre-existing precedence must not regress for self-hosters.
+    creds("ck_live_from_file\n")
+    monkeypatch.setenv("VLLM_API_KEY", "local-server-key")
+    assert config.api_key() == "local-server-key"
+
+
+def test_unreadable_file_degrades_to_empty(creds, tmp_path):
+    # A directory where the file should be is the cheap portable stand-in for
+    # "open() raises". Must not propagate an exception into the solve path.
+    (tmp_path / "credentials").mkdir()
+    assert config.api_key() == "EMPTY"
+
+
+def test_credentials_path_follows_the_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("CAPTCHA_KRAKEN_STATE_DIR", str(tmp_path))
+    assert config.credentials_path() == tmp_path / "credentials"

--- a/python/tests/test_object_detection.py
+++ b/python/tests/test_object_detection.py
@@ -8,6 +8,14 @@ from PIL import Image
 # Add src to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
+# DEAD SINCE THE MONOREPO RESTRUCTURE (529f144). `attention` was a v1-architecture
+# module; v1 is preserved on the `v1-old-architecture` branch and this module does
+# not exist here, so this file has been uncollectable — it did not fail CI only
+# because CI ran a four-file allowlist. Skipping visibly instead of silently
+# ignoring it. Either port these to the v2 planner or delete the file; a test that
+# can never run is not coverage.
+pytest.importorskip("attention", reason="v1-only module; see comment above")
+
 from attention import AttentionExtractor
 
 # Paths

--- a/python/tests/test_pinned_model.py
+++ b/python/tests/test_pinned_model.py
@@ -1,0 +1,86 @@
+"""The pinned (model, prompt) pair must stay internally consistent.
+
+`pinned_model.json` records the adapter this release was validated against and
+the SHA-256 of each prompt we send it. The adapter and the prompts are a matched
+pair: the LoRA is trained to answer one exact prompt, so changing either half
+alone silently degrades or breaks solving.
+
+That is not hypothetical. On 2026-07-18 the adapter was retrained on the content
+schema (`action: drag` / `drags[]` / lowercase) while planner.py still asked for
+the legacy `output` / `simulate_drag` / PascalCase schema. The model replied in a
+hybrid of the two, the parser dropped it, and every drag puzzle failed as
+"unsupported" — with nothing in CI going red, because train/grade parity inside
+the finetune repo was intact. Only the SHIPPED prompt had drifted.
+
+So: editing a serving prompt fails this test until someone updates the manifest,
+which forces the question "does the pinned adapter still expect this prompt?".
+Hermetic — reads constants and a JSON file, no model or network.
+"""
+import hashlib
+
+from captchakraken import config
+from captchakraken.planner import PIXEL_ACTION_PROMPT, SELECT_GRID_PROMPT
+
+# The prompts CI guards, by the name used in pinned_model.json.
+SERVING_PROMPTS = {
+    "PIXEL_ACTION_PROMPT": PIXEL_ACTION_PROMPT,
+    "SELECT_GRID_PROMPT": SELECT_GRID_PROMPT,
+}
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def test_manifest_has_every_field_config_reads():
+    manifest = config.pinned()
+    for key in ("base_model", "lora_adapter", "lora_revision", "lora_name", "prompt_sha256"):
+        assert key in manifest, f"pinned_model.json is missing '{key}'"
+
+
+def test_config_defaults_come_from_the_manifest(monkeypatch):
+    """With no env overrides, config must report exactly what is pinned."""
+    for var in (
+        "CAPTCHA_BASE_MODEL",
+        "CAPTCHA_LORA_ADAPTER",
+        "CAPTCHA_LORA_REVISION",
+        "CAPTCHA_LORA_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    manifest = config.pinned()
+    assert config.base_model() == manifest["base_model"]
+    assert config.lora_adapter() == manifest["lora_adapter"]
+    assert config.lora_revision() == manifest["lora_revision"]
+    assert config.lora_name() == manifest["lora_name"]
+
+
+def test_env_still_overrides_the_pin(monkeypatch):
+    """The pin is a default, not a lock — self-hosters must keep their override."""
+    monkeypatch.setenv("CAPTCHA_LORA_ADAPTER", "someone-else/their-adapter")
+    assert config.lora_adapter() == "someone-else/their-adapter"
+
+
+def test_every_guarded_prompt_is_listed_in_the_manifest():
+    pinned_names = set(config.pinned()["prompt_sha256"])
+    assert pinned_names == set(SERVING_PROMPTS), (
+        "pinned_model.json prompt_sha256 keys drifted from the prompts this test "
+        "guards. A new serving prompt must be pinned too — an unpinned prompt is "
+        "exactly the hole that let the 2026-07-18 drag regression ship."
+    )
+
+
+def test_serving_prompts_match_their_pinned_hashes():
+    expected = config.pinned()["prompt_sha256"]
+    drifted = {
+        name: (expected[name], _sha256(text))
+        for name, text in SERVING_PROMPTS.items()
+        if _sha256(text) != expected[name]
+    }
+    assert not drifted, (
+        "A serving prompt changed but pinned_model.json was not updated:\n"
+        + "\n".join(f"  {n}: pinned {p[:12]}… now {a[:12]}…" for n, (p, a) in drifted.items())
+        + "\n\nThe LoRA is trained to answer one exact prompt. If this change is "
+        "intentional, confirm the pinned adapter still expects the new wording, "
+        "run the Tier 2 static-image gate, then update prompt_sha256."
+    )

--- a/python/tests/test_routing_headers.py
+++ b/python/tests/test_routing_headers.py
@@ -1,0 +1,41 @@
+"""Tests for the fleet-routing priority header.
+
+`routing_headers` turns CAPTCHA_REQUEST_PRIORITY into the `X-JH-Priority` header
+that the fleet's haproxy front routes on (values >5 → backup GPUs). The whole
+point is that it fires ONLY when deliberately set — an unset or malformed value
+must never silently tag production traffic for the backups — so that boundary is
+what these pin. Hermetic: no server, no network.
+"""
+from captchakraken.planner import _PRIORITY_HEADER, routing_headers
+
+
+def test_no_priority_env_yields_no_header():
+    assert routing_headers(env={}) == {}
+
+
+def test_empty_or_whitespace_value_yields_no_header():
+    assert routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": ""}) == {}
+    assert routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": "   "}) == {}
+
+
+def test_non_integer_value_is_ignored_not_forwarded():
+    # A typo must not tag traffic — better no routing than wrong routing.
+    assert routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": "low"}) == {}
+    assert routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": "5.5"}) == {}
+
+
+def test_integer_value_becomes_the_header():
+    assert routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": "10"}) == {_PRIORITY_HEADER: "10"}
+
+
+def test_value_is_normalized_to_a_bare_int_string():
+    # haproxy compares it as an integer (req.hdr_val), so surrounding whitespace
+    # or a leading zero must not reach the wire as-is.
+    assert routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": " 07 "}) == {_PRIORITY_HEADER: "7"}
+
+
+def test_the_tier2_default_of_10_clears_the_routing_threshold():
+    # tier2_gate.sh defaults CAPTCHA_REQUEST_PRIORITY=10; haproxy routes >5 to the
+    # backups, so 10 must survive as an int well above the threshold.
+    hdr = routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": "10"})
+    assert int(hdr[_PRIORITY_HEADER]) > 5

--- a/python/tests/test_routing_headers.py
+++ b/python/tests/test_routing_headers.py
@@ -1,12 +1,23 @@
-"""Tests for the fleet-routing priority header.
+"""Tests for the fleet-routing and hosted-API request headers.
 
 `routing_headers` turns CAPTCHA_REQUEST_PRIORITY into the `X-JH-Priority` header
 that the fleet's haproxy front routes on (values >5 → backup GPUs). The whole
 point is that it fires ONLY when deliberately set — an unset or malformed value
 must never silently tag production traffic for the backups — so that boundary is
 what these pin. Hermetic: no server, no network.
+
+It also emits the two hosted-API headers: `X-CK-Client` (which integration made
+the request, used to attribute camoufox revenue) and `X-CK-Session` (groups the
+rounds of one captcha into a single billable attempt). Both carry money
+implications, so the tests below pin that they are absent unless set, survive
+independently of a malformed priority, and can never inject extra headers.
 """
-from captchakraken.planner import _PRIORITY_HEADER, routing_headers
+from captchakraken.planner import (
+    _CLIENT_HEADER,
+    _PRIORITY_HEADER,
+    _SESSION_HEADER,
+    routing_headers,
+)
 
 
 def test_no_priority_env_yields_no_header():
@@ -39,3 +50,55 @@ def test_the_tier2_default_of_10_clears_the_routing_threshold():
     # backups, so 10 must survive as an int well above the threshold.
     hdr = routing_headers(env={"CAPTCHA_REQUEST_PRIORITY": "10"})
     assert int(hdr[_PRIORITY_HEADER]) > 5
+
+
+# ── Hosted-API headers ──────────────────────────────────────────────────────
+
+
+def test_self_hosted_users_send_neither_hosted_header():
+    # The default path must stay byte-identical for self-hosters.
+    assert routing_headers(env={}) == {}
+
+
+def test_client_and_session_are_forwarded_when_set():
+    hdrs = routing_headers(
+        env={
+            "CAPTCHA_KRAKEN_CLIENT": "camoufox/0.4.11",
+            "CAPTCHA_KRAKEN_SESSION": "6f1a2b3c-0000-4000-8000-000000000001",
+        }
+    )
+    assert hdrs[_CLIENT_HEADER] == "camoufox/0.4.11"
+    assert hdrs[_SESSION_HEADER] == "6f1a2b3c-0000-4000-8000-000000000001"
+
+
+def test_blank_values_are_dropped_rather_than_sent_empty():
+    # An empty header would read as "attributed to nothing" downstream; absent is
+    # unambiguous.
+    assert routing_headers(env={"CAPTCHA_KRAKEN_CLIENT": "   "}) == {}
+    assert routing_headers(env={"CAPTCHA_KRAKEN_SESSION": ""}) == {}
+
+
+def test_a_malformed_priority_does_not_suppress_attribution():
+    # Regression guard: the headers are derived independently. If a typo'd
+    # priority swallowed the client header, camoufox traffic would silently be
+    # counted as direct and understate the partner's revenue share.
+    hdrs = routing_headers(
+        env={"CAPTCHA_REQUEST_PRIORITY": "oops", "CAPTCHA_KRAKEN_CLIENT": "camoufox/1.0"}
+    )
+    assert hdrs == {_CLIENT_HEADER: "camoufox/1.0"}
+
+
+def test_crlf_cannot_inject_additional_headers():
+    # These values come from the environment and reach the wire verbatim, so a
+    # newline must never be able to splice in another header.
+    hdrs = routing_headers(
+        env={"CAPTCHA_KRAKEN_CLIENT": "camoufox\r\nX-CK-Session: forged"}
+    )
+    assert hdrs == {_CLIENT_HEADER: "camoufoxX-CK-Session: forged"}
+    assert "\r" not in hdrs[_CLIENT_HEADER] and "\n" not in hdrs[_CLIENT_HEADER]
+    assert _SESSION_HEADER not in hdrs
+
+
+def test_oversized_value_is_truncated_not_dropped():
+    hdrs = routing_headers(env={"CAPTCHA_KRAKEN_CLIENT": "c" * 500})
+    assert len(hdrs[_CLIENT_HEADER]) == 128

--- a/python/tests/test_solver_contract.py
+++ b/python/tests/test_solver_contract.py
@@ -1,0 +1,230 @@
+"""Solver contract: every puzzle type, every response shape the model emits.
+
+This is the layer between "the model is accurate" and "the browser solved it".
+Accuracy graders (grade.py in the finetune repo) score the model's RAW TEXT, so
+they cannot see a parser or dispatch bug — a perfectly correct answer that the
+planner drops still grades as a correct answer. The live browser harness would
+catch it, but only for whichever puzzle type a demo page happened to serve.
+
+That gap is exactly how the 2026-07-18 drag regression shipped: the adapter was
+retrained on the content schema while the serving prompt still asked for the
+legacy one, the model replied in a hybrid, `_normalize_pixel` returned [], and
+every drag puzzle failed as "unsupported".
+
+So these tests assert, for EVERY puzzle type we ship:
+  1. the response shapes the model actually emits parse, and
+  2. they normalize to the correct ACTION KIND with the correct coordinates.
+
+Scope, stated plainly: the planner's parsing is type-AGNOSTIC — it reads the
+JSON, not the puzzle. So parametrizing over puzzle types does not exercise 26
+different code paths. What it buys is (a) a failure names the puzzle type it
+breaks, and (b) the type→kind map below is pinned and must be extended when a
+type is added, so no type reaches production with nobody having decided what it
+should emit. Whether the MODEL actually returns the right kind for a given
+image is a Tier 2 question, answered against real held-out samples.
+
+Hermetic — pure string/JSON parsing, no model, network, or image. Coordinate
+regressions for individual malformed shapes live in test_pixel_parser.py; this
+file is about per-type coverage of the contract.
+"""
+import pytest
+
+from captchakraken.planner import ActionPlanner
+
+# ── The shipping puzzle-type set ────────────────────────────────────────────
+# Union of the finetune repo's generator registry (src/synthetic/cli.py
+# GENERATORS), the hand-labeled held-out set (cleanSamples/test/
+# test_solutions.json), and its scoring taxonomy (src/testing/eval_unified.py).
+# 26 types as of 2026-07-20. A type the solver can be handed but that no test
+# exercises is how a whole puzzle class regresses unnoticed.
+#
+# NOTE: five of these are absent from eval_unified.py's GRID/CLICK/*_DRAG sets.
+# For the two with real held-out samples (hcaptcha_click_described_item, n=12;
+# hcaptcha_block_cover, n=1) that is a live scoring bug — they fall through
+# every branch in evaluate(), so `ok` stays False and they score a permanent 0%
+# no matter what the model returns. Kinds below were read off their labeled
+# answers in test_solutions.json, not guessed.
+GRID_TYPES = {
+    "recaptcha_grid_3x3",
+    "recaptcha_grid_4x4",
+    "hcaptcha_grid_3x3_property",
+}
+CLICK_TYPES = {
+    "hcaptcha_arrows_deviating",
+    "hcaptcha_car_parking_lot",
+    "hcaptcha_click_described_item",   # untaxonomized in eval_unified (n=12)
+    "hcaptcha_click_highest_jumper",
+    "hcaptcha_click_image_by_traits",
+    "hcaptcha_click_items_in_grid",    # stub generator, no samples yet
+    "hcaptcha_click_on_path",
+    "hcaptcha_grocery_list",           # stub generator, no samples yet
+    "hcaptcha_line_ends",
+    "hcaptcha_overlapping_lines",
+    "hcaptcha_silhouette_match",
+}
+DRAG_TYPES = {
+    "hcaptcha_block_cover",            # untaxonomized in eval_unified (n=1)
+    "hcaptcha_connect_path",
+    "hcaptcha_drag_fruit_to_plate",    # stub generator, no samples yet
+    "hcaptcha_drag_missing_slot",
+    "hcaptcha_drag_numbered_line_pieces",
+    "hcaptcha_fish_swim_different",
+    "hcaptcha_line_connecting_images",
+    "hcaptcha_line_pieces",
+    "hcaptcha_missing_piece",
+    "hcaptcha_most_similar_or_different",
+    "hcaptcha_semicircle_match",
+    "hcaptcha_tetris_fit",
+}
+ALL_TYPES = GRID_TYPES | CLICK_TYPES | DRAG_TYPES
+
+
+def _click(data):
+    """Normalize and return click points rounded for comparison."""
+    actions = ActionPlanner._normalize_pixel(data)
+    assert actions, "response normalized to no action at all"
+    assert all(a["kind"] == "click" for a in actions), (
+        f"expected click actions, got kinds {[a['kind'] for a in actions]}"
+    )
+    return [(round(x, 3), round(y, 3)) for a in actions for x, y in a["points"]]
+
+
+def _drags(data):
+    """Normalize and return (src, dst) pairs rounded for comparison."""
+    actions = ActionPlanner._normalize_pixel(data)
+    assert actions, "response normalized to no action at all"
+    assert all(a["kind"] == "drag" for a in actions), (
+        f"expected drag actions, got kinds {[a['kind'] for a in actions]}"
+    )
+    return [
+        ((round(a["src"][0], 3), round(a["src"][1], 3)),
+         (round(a["dst"][0], 3), round(a["dst"][1], 3)))
+        for a in actions
+    ]
+
+
+# ── Response shapes, keyed by action kind ───────────────────────────────────
+# Each entry is (variant_name, raw_model_text). Raw TEXT, not dicts, so every
+# case exercises _parse_json (fence stripping, brace balancing, strict=False)
+# as well as _normalize_*. Variants are the shapes seen in production, not
+# invented ones.
+
+CLICK_SHAPES = [
+    # The canonical content schema PIXEL_ACTION_PROMPT asks for.
+    ("canonical_subjects_points",
+     '{"action": "click", "subjects": ["duck", "penguin"], '
+     '"points": [[250, 400], [600, 750]]}'),
+    # Same, wrapped in a fenced code block.
+    ("fenced_json",
+     '```json\n{"action": "click", "subjects": ["duck", "penguin"], '
+     '"points": [[250, 400], [600, 750]]}\n```'),
+    # Nested under "action" — a shape the model drifts into.
+    ("nested_action_dict",
+     '{"action": {"action": "click", "points": [[250, 400], [600, 750]]}}'),
+    # Truncated at max_tokens; _balance_json must repair it.
+    ("truncated_unbalanced",
+     '{"action": {"points": [[250, 400], [600, 750]'),
+]
+CLICK_EXPECTED = [(0.25, 0.4), (0.6, 0.75)]
+
+DRAG_SHAPES = [
+    # The canonical content schema — lowercase action, drags[], from/to.
+    ("canonical_drags",
+     '{"action": "drag", "drags": [{"source": "piece", "from": [200, 300], '
+     '"destination": "slot", "to": [700, 800]}]}'),
+    # Legacy PascalCase output[] schema — pre-content-schema adapters, and the
+    # shape the hand-labeled block_cover answers are stored in.
+    ("legacy_output_pascalcase",
+     '{"output": [{"Action": "simulate_drag", '
+     '"SourcePosition": {"x": 200, "y": 300}, '
+     '"EstimatedPosition": {"x": 700, "y": 800}}]}'),
+    # snake_case simulate_drag with coords packed as {"x": [x, y]}.
+    ("simulate_drag_snake_packed",
+     '{"action": {"simulate_drag": [{"source_position": {"x": [200, 300]}, '
+     '"destination_position": {"x": [700, 800]}}]}}'),
+    # simulate_drag as a SINGLE OBJECT rather than a list — silently dropped
+    # as "unsupported" before the single-object normalization landed.
+    ("simulate_drag_single_object",
+     '{"simulate_drag": {"sourcePosition": [200, 300], '
+     '"destinationPosition": [700, 800]}}'),
+]
+DRAG_EXPECTED = [((0.2, 0.3), (0.7, 0.8))]
+
+GRID_SHAPES = [
+    # The trained shape: a bare JSON array.
+    ("bare_array", "[1, 5, 9]", [1, 5, 9]),
+    ("fenced_bare_array", "```json\n[1, 5, 9]\n```", [1, 5, 9]),
+    ("target_ids_wrapped", '{"target_ids": [1, 5, 9]}', [1, 5, 9]),
+    ("nested_target_ids", '{"action": {"target_ids": [1, 5, 9]}}', [1, 5, 9]),
+    ("stringified_ids", '["1", "5", "9"]', [1, 5, 9]),
+    # "No tiles match" is a VALID answer, not a parse failure — the prompt
+    # explicitly asks for [] when everything has been cleared.
+    ("empty_is_valid", "[]", []),
+    # Junk must be dropped without costing the rest of the selection.
+    ("out_of_range_dropped", "[1, 0, 5, 99, 9]", [1, 5, 9]),
+]
+
+
+@pytest.mark.parametrize("puzzle_type", sorted(CLICK_TYPES))
+@pytest.mark.parametrize("variant,raw", CLICK_SHAPES, ids=lambda v: v if isinstance(v, str) else "")
+def test_click_types_normalize_to_click_actions(puzzle_type, variant, raw):
+    data = ActionPlanner._parse_json(raw)
+    assert data is not None, f"{puzzle_type}/{variant}: response did not parse at all"
+    assert _click(data) == CLICK_EXPECTED, f"{puzzle_type}/{variant}"
+
+
+@pytest.mark.parametrize("puzzle_type", sorted(DRAG_TYPES))
+@pytest.mark.parametrize("variant,raw", DRAG_SHAPES, ids=lambda v: v if isinstance(v, str) else "")
+def test_drag_types_normalize_to_drag_actions(puzzle_type, variant, raw):
+    data = ActionPlanner._parse_json(raw)
+    assert data is not None, f"{puzzle_type}/{variant}: response did not parse at all"
+    assert _drags(data) == DRAG_EXPECTED, f"{puzzle_type}/{variant}"
+
+
+@pytest.mark.parametrize("puzzle_type", sorted(GRID_TYPES))
+@pytest.mark.parametrize(
+    "variant,raw,expected", GRID_SHAPES, ids=lambda v: v if isinstance(v, str) else ""
+)
+def test_grid_types_normalize_to_cell_ids(puzzle_type, variant, raw, expected):
+    total = 16 if puzzle_type == "recaptcha_grid_4x4" else 9
+    data = ActionPlanner._parse_json(raw)
+    assert ActionPlanner._normalize_grid(data, total) == expected, f"{puzzle_type}/{variant}"
+
+
+def test_multi_drag_returns_every_drag():
+    """Multi-drag types must not collapse to a single drag — line_pieces and
+    friends need all of them, and dropping the tail looks like a solve that
+    just didn't finish."""
+    raw = (
+        '{"action": "drag", "drags": ['
+        '{"source": "a", "from": [100, 100], "destination": "x", "to": [900, 100]},'
+        '{"source": "b", "from": [200, 200], "destination": "y", "to": [800, 200]},'
+        '{"source": "c", "from": [300, 300], "destination": "z", "to": [700, 300]}]}'
+    )
+    assert _drags(ActionPlanner._parse_json(raw)) == [
+        ((0.1, 0.1), (0.9, 0.1)),
+        ((0.2, 0.2), (0.8, 0.2)),
+        ((0.3, 0.3), (0.7, 0.3)),
+    ]
+
+
+def test_unusable_response_yields_no_action_rather_than_a_wrong_one():
+    """Garbage must normalize to [] so the solver raises UnsupportedCaptchaError
+    and can retry — never to a plausible-looking click at (0, 0)."""
+    for raw in ('{"action": "click", "subjects": ["duck"]}',   # labels, no points
+                '{"reasoning": "I cannot see the image"}',
+                "I'm not able to solve this captcha.",
+                ""):
+        assert ActionPlanner._normalize_pixel(ActionPlanner._parse_json(raw)) == []
+
+
+def test_every_shipping_puzzle_type_is_covered():
+    """Guard against adding a puzzle type without adding contract coverage."""
+    assert len(ALL_TYPES) == 26, (
+        f"the shipping puzzle-type set changed ({len(ALL_TYPES)} types, expected 26). "
+        "Add the new type to GRID_TYPES / CLICK_TYPES / DRAG_TYPES above so it gets "
+        "contract coverage, then update this count."
+    )
+    assert not (GRID_TYPES & CLICK_TYPES), "a type cannot be both grid and click"
+    assert not (GRID_TYPES & DRAG_TYPES), "a type cannot be both grid and drag"
+    assert not (CLICK_TYPES & DRAG_TYPES), "a type cannot be both click and drag"


### PR DESCRIPTION
Brings `main` up to date with the branch. Two things matter here.

**`X-CK-Client` / `X-CK-Session` are not in any released client.** The gateway
reads both — `usage_events.client` and `usage_events.session_id` — and the
partner agreement measures camoufox-brought revenue per request. Until this
lands, every solve from the published package is unattributed, and the revenue
split has no data to work from. This was caught by a contract test in the
gateway repo that reads this file directly and asserts the markers are present.

**Session ids cap what a captcha can cost.** A dynamic reCAPTCHA 3x3 re-solves
after each click round, so one `solve()` can fire several model calls. Sharing
one UUID across them lets the gateway bill a capped attempt rather than N
independent rounds.

Both headers are optional and absent unless set, so self-hosted users send
neither and are unaffected. Values are sanitized to printable ASCII and
length-capped, because they reach the wire verbatim from the environment and a
CR/LF would splice arbitrary headers into the upstream request.

Also adds the credentials-file fallback in `config.api_key()`, so the MCP
signup flow can write a 0600 key file instead of returning a key through an
agent transcript. Precedence is env, then file, then `EMPTY` — self-hosted
users without the file are unaffected.

`python -m pytest -q` locally: 197 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)