### PR TITLE
2.4.0 — make the hosted API usable end to end (A1–A5)

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -1,0 +1,74 @@
+/**
+ * A twenty-line MCP client, so CI can prove the server actually speaks MCP.
+ *
+ *   node .github/scripts/mcp-smoke.mjs node dist/index.js
+ *
+ * Does the real handshake over stdio — initialize, notifications/initialized,
+ * tools/list — and exits non-zero unless at least one tool comes back.
+ *
+ * WHY THIS EXISTS RATHER THAN JUST `tsc`: the failure mode worth catching is a
+ * server that compiles perfectly and then cannot complete a handshake, because
+ * that ships green and breaks in the user's editor. The two ways it happens are
+ * a transport wired up wrong and — much more likely here — something writing to
+ * stdout, which IS the protocol channel: one stray console.log corrupts every
+ * frame. This catches both.
+ *
+ * Hermetic: tools/list is answered before any sign-in, so no credentials, no
+ * network, and nothing to clean up.
+ */
+import { spawn } from 'node:child_process';
+
+const cmd = process.argv[2];
+const args = process.argv.slice(3);
+const proc = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+let buf = '';
+const pending = new Map();
+
+proc.stdout.on('data', (d) => {
+  buf += d.toString();
+  let i;
+  while ((i = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, i).trim();
+    buf = buf.slice(i + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { console.error('non-JSON on stdout:', line); continue; }
+    if (msg.id && pending.has(msg.id)) pending.get(msg.id)(msg);
+  }
+});
+
+const stderrChunks = [];
+proc.stderr.on('data', (d) => stderrChunks.push(d.toString()));
+
+function send(obj) { proc.stdin.write(JSON.stringify(obj) + '\n'); }
+function request(id, method, params) {
+  return new Promise((resolve, reject) => {
+    pending.set(id, resolve);
+    send({ jsonrpc: '2.0', id, method, params });
+    setTimeout(() => reject(new Error(`timeout waiting for ${method}`)), 15000);
+  });
+}
+
+try {
+  const init = await request(1, 'initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'smoke', version: '0.0.0' },
+  });
+  console.log('initialize OK — server:', JSON.stringify(init.result?.serverInfo));
+
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+  const tools = await request(2, 'tools/list', {});
+  const names = (tools.result?.tools ?? []).map((t) => t.name);
+  console.log(`tools/list OK — ${names.length} tools:`);
+  for (const n of names) console.log('  -', n);
+  process.exitCode = names.length > 0 ? 0 : 1;
+} catch (e) {
+  console.error('FAILED:', e.message);
+  console.error('stderr was:\n' + stderrChunks.join(''));
+  process.exitCode = 1;
+} finally {
+  proc.kill();
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,31 @@ jobs:
         run: |
           node scripts/copy-python.mjs
           npx tsc --noEmit -p tsconfig.json
+
+  mcp-build:
+    name: MCP server build (TypeScript)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+      - run: npm ci
+      - name: Type-check + build
+        run: |
+          npx tsc --noEmit -p tsconfig.json
+          npm run build
+      # The server is only useful if it SPEAKS MCP, and a package that compiles
+      # but cannot complete a handshake would ship green. This starts the built
+      # binary over stdio, initializes, and asserts tools/list comes back
+      # non-empty — the same check A4 was signed off on by hand.
+      #
+      # No credentials involved: tools/list is answered before any sign-in, so
+      # this stays hermetic like the rest of the gate.
+      - name: Answers an MCP handshake
+        run: node ../.github/scripts/mcp-smoke.mjs node dist/index.js

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,22 @@ name: Publish
 # Each publish is idempotent (a version already on the registry is skipped, not
 # failed), so re-running a partially-failed release is safe.
 #
-# Auth is TOKENLESS via OIDC trusted publishing on both registries — no secrets.
-# One-time config (after any repo rename, redo these):
+# Auth is TOKENLESS via OIDC trusted publishing on all three — no secrets.
+# One-time config, PER PACKAGE (after any repo rename, redo all of these):
 #   npm:  npmjs.com → captchakraken → Settings → Trusted Publisher →
 #         GitHub Actions: JWriter20/CaptchaKraken, workflow publish.yml
+#   npm:  npmjs.com → captchakraken-mcp → same, as its own entry. The
+#         `captchakraken` entry does NOT cover it; trusted publishers are scoped
+#         to one package name.
 #   PyPI: pypi.org → captchakraken → Publishing → add a GitHub trusted publisher:
 #         JWriter20/CaptchaKraken, workflow publish.yml
+#
+# A BRAND-NEW npm package cannot be configured before it exists: npm's trusted
+# publisher settings live on the package page. So the FIRST publish of
+# captchakraken-mcp needs a one-off `npm publish` from a logged-in machine (or a
+# pending-publisher entry created on npmjs.com); every release after that is
+# tokenless like the rest. This is a one-time cost and it is why publish-mcp can
+# legitimately fail on the very first run while the other two jobs succeed.
 on:
   push:
     branches: [main]
@@ -56,6 +66,47 @@ jobs:
           VER=$(node -p "require('./package.json').version")
           if npm view "captchakraken@$VER" version >/dev/null 2>&1; then
             echo "captchakraken@$VER already published — skipping."
+          else
+            npm publish --access public --provenance
+          fi
+
+  # The MCP server is a SEPARATE package on its own version line (0.1.0 while
+  # the client is at 2.4.0) and is deliberately not locked to the client's
+  # number: tying them together would mean cutting an MCP release every time the
+  # solver changes. What ties them is the repo and the release train, not the
+  # integer — and `npm view` below reads this manifest independently anyway.
+  #
+  # It is NOT a dependency of the `captchakraken` package on purpose. The client
+  # has one runtime dep; the MCP needs the MCP SDK and zod. Those belong on the
+  # one-time onboarding path, not on every browser-driver install.
+  publish-mcp:
+    name: Publish npm (captchakraken-mcp)
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # OIDC trusted publishing + provenance
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # Node 24 for the same reason as publish-npm: trusted publishing needs
+          # npm >= 11.5.1, and self-upgrading npm inside the toolcache breaks
+          # `publish --provenance`.
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+      - run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Publish (idempotent)
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          if npm view "captchakraken-mcp@$VER" version >/dev/null 2>&1; then
+            echo "captchakraken-mcp@$VER already published — skipping."
           else
             npm publish --access public --provenance
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 All notable changes to CaptchaKraken are documented here. This project follows
 semantic versioning; v2 is a major, **breaking** release.
 
+## [2.4.0] — 2026-07-29
+
+The release that makes the **hosted** API usable by someone who has never heard
+of vLLM. Nothing here changes self-hosting.
+
+### Added
+- **`captchakraken-mcp`, a new npm package**, published from this repo as a
+  third workspace (`mcp/`). Signs you in with GitHub, mints a solving key, and
+  reports balance, usage and a top-up link. `npx captchakraken-mcp`.
+
+  It is a **separate install** from `captchakraken`, deliberately: `npx`
+  resolves by package name, and the MCP's dependencies have no business on
+  every browser-driver install. It also keeps its own version line — 0.1.0
+  here — so a solver change does not force an MCP release.
+- `CaptchaKrakenAPIError` is exported from the TypeScript port, carrying
+  `code`, `resolutionUrl` and `retryAfterSeconds`. Branch on `code`; the prose
+  is not a contract.
+- The credentials file may now carry the **endpoint** alongside the key
+  (`VLLM_BASE_URL=` or `CAPTCHA_KRAKEN_BASE_URL=`).
+
+### Changed
+- **Hosted-API refusals now explain themselves.** Running out of credits used
+  to produce `vLLM 402 Payment Required at https://api.captchakraken.com/...`,
+  naming infrastructure the user never installed. Out of credits, rate limited,
+  account suspended, request too large, and abandoned attempts now each produce
+  a sentence naming CaptchaKraken and the URL that resolves it, in both ports.
+  429 honours `Retry-After`.
+
+  An unrecognised code still produces a useful message — it carries the
+  server's own text through — rather than falling back to something generic.
+- **`create_api_key` no longer returns the secret.** It writes
+  `~/.captchakraken/credentials` at 0600 and reports the path, so a live key
+  cannot reach an agent transcript. It writes the endpoint at the same time.
+- **A key from the MCP no longer needs `VLLM_BASE_URL` set.** `base_url()`
+  reads the credentials file when the env var is absent, so a hosted user's
+  first solve reaches `api.captchakraken.com` instead of dialling a local port
+  with nothing behind it. An explicit `VLLM_BASE_URL` still wins, and a machine
+  with no credentials file still defaults to localhost.
+
+### Unchanged, on purpose
+- Self-hosting. A local vLLM sends no error envelope, so it still produces the
+  old message, bearer-token hint and all. A bare-token credentials file still
+  yields no endpoint, so nobody who hand-wrote a local key into that file gets
+  silently redirected at our servers.
+
 ## [2.3.0] — 2026-07-24
 
 ### Added

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "captchakraken",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "captchakraken",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captchakraken",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Browser-agnostic Playwright/Puppeteer captcha solver. Detects the captcha, reads the grid with a fine-tuned Qwen3.5-9B vision model on vLLM, and clicks through to a token.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -1,0 +1,107 @@
+/**
+ * Hosted-API refusals, carried across the Python subprocess boundary.
+ *
+ * The TypeScript driver does not talk to the model; it shells out to the Python
+ * CLI, which does. So every hosted-API error arrives here as text on stderr and
+ * would, without this, be flattened into
+ * `Failed to execute captcha solver CLI: Command failed with exit code 3` —
+ * a sentence that tells a camoufox user nothing about the fact that their
+ * account is out of credits.
+ *
+ * The CLI exits 3 and prints `{"error": "...", "ck_error": {...}}`, so the
+ * wording is decided once, in Python (`captchakraken/errors.py`), and merely
+ * relayed here. Deliberately NOT re-worded on this side: two copies of the same
+ * message drift, and the Python one is also what a direct CLI user sees.
+ */
+
+/** The machine-readable half. Mirrors the gateway's `GatewayErrorCode`. */
+export type CaptchaKrakenErrorCode =
+  | 'missing_api_key'
+  | 'invalid_api_key'
+  | 'account_suspended'
+  | 'insufficient_credits'
+  | 'rate_limited'
+  | 'solve_abandoned'
+  | 'unrecognized_prompt'
+  | 'invalid_request'
+  | 'request_too_large'
+  | 'upstream_unavailable'
+  // Not a closed set on purpose — a code added to the gateway after this was
+  // written must still arrive intact rather than being coerced to a fallback.
+  | (string & {});
+
+export class CaptchaKrakenAPIError extends Error {
+  readonly status: number | undefined;
+  readonly code: CaptchaKrakenErrorCode | undefined;
+  /** Where to send the user to fix it, when the server named somewhere. */
+  readonly resolutionUrl: string | undefined;
+  /** Seconds to wait, on `rate_limited`. */
+  readonly retryAfterSeconds: number | undefined;
+  /** Lets `catch` blocks branch without `instanceof` across module copies. */
+  readonly isCaptchaKrakenAPIError = true;
+
+  constructor(
+    message: string,
+    fields: {
+      status?: number;
+      code?: string;
+      resolutionUrl?: string;
+      retryAfterSeconds?: number;
+    } = {},
+  ) {
+    super(message);
+    this.name = 'CaptchaKrakenAPIError';
+    this.status = fields.status;
+    this.code = fields.code;
+    this.resolutionUrl = fields.resolutionUrl;
+    this.retryAfterSeconds = fields.retryAfterSeconds;
+  }
+}
+
+/**
+ * Pull a hosted-API error out of the CLI's stderr, or return null.
+ *
+ * Scans line by line rather than parsing the whole buffer: stderr also carries
+ * timing records and any warning the Python side emitted, so the JSON payload
+ * is one line among several and `JSON.parse(stderr)` would simply fail.
+ *
+ * Returns null for anything that is not recognisably ours, which leaves the
+ * caller's existing generic handling in place — an unparseable stderr must not
+ * become a confident but wrong billing message.
+ */
+export function parseApiError(stderr: string): CaptchaKrakenAPIError | null {
+  if (!stderr || !stderr.includes('ck_error')) return null;
+
+  for (const line of stderr.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{') || !trimmed.includes('ck_error')) continue;
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const details = parsed?.ck_error;
+    if (!details || typeof details !== 'object') continue;
+
+    const message =
+      typeof parsed.error === 'string' && parsed.error.trim()
+        ? parsed.error
+        : 'CaptchaKraken refused this solve.';
+
+    return new CaptchaKrakenAPIError(message, {
+      status: typeof details.status === 'number' ? details.status : undefined,
+      code: typeof details.code === 'string' ? details.code : undefined,
+      resolutionUrl:
+        typeof details.resolution_url === 'string' ? details.resolution_url : undefined,
+      retryAfterSeconds:
+        typeof details.retry_after_seconds === 'number'
+          ? details.retry_after_seconds
+          : undefined,
+    });
+  }
+
+  return null;
+}

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -2,6 +2,30 @@ export * from './types';
 export { CaptchaKrakenSolver } from './solver';
 
 /**
+ * Errors raised when the **hosted** CaptchaKraken API refuses a solve — out of
+ * credits, rate limited, key rejected, attempt abandoned.
+ *
+ * `message` is already a complete sentence naming the product and, where one
+ * exists, the URL that fixes it, so printing it is enough. `code` is the stable
+ * contract to branch on; the prose is not.
+ *
+ * @example
+ * ```typescript
+ * import { CaptchaKrakenSolver, CaptchaKrakenAPIError } from 'captchakraken';
+ *
+ * try {
+ *   await solver.solve(page);
+ * } catch (e) {
+ *   if (e instanceof CaptchaKrakenAPIError && e.code === 'insufficient_credits') {
+ *     console.error(`Top up: ${e.resolutionUrl}`);
+ *   } else throw e;
+ * }
+ * ```
+ */
+export { CaptchaKrakenAPIError } from './errors';
+export type { CaptchaKrakenErrorCode } from './errors';
+
+/**
  * Adapter for driving the solver with **Puppeteer** instead of a Playwright
  * launcher. Puppeteer's `Page` is API-compatible with Playwright's except for a
  * few method names/options; `fromPuppeteer(page)` wraps it so `solve()` accepts

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -20,6 +20,7 @@ import * as os from 'os';
 import { createHash, randomUUID } from 'crypto';
 import { CaptchaKrakenConfig, SolverResult, ClickAction, CaptchaAction, SolveResult, CliResponse, TokenUsage, Vector, SolveStepEvent } from './types';
 import { aggregateTokenUsage } from './token-usage';
+import { parseApiError } from './errors';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -1968,6 +1969,18 @@ export class CaptchaKrakenSolver {
         (e as any).unsupported = true;
         throw e;
       }
+
+      // The hosted API refused the solve and said why (out of credits, rate
+      // limited, attempt abandoned…). The CLI exits 3 with the already-worded
+      // sentence plus the machine-readable fields; both are rethrown as-is.
+      //
+      // Wrapping this in "Failed to execute captcha solver CLI: Command failed
+      // …" — which is what happens to every other non-zero exit — would bury a
+      // billing problem under a sentence about a subprocess. camoufox surfaces
+      // whatever we throw, so this is the message its users actually read.
+      const apiError = parseApiError(stderr);
+      if (apiError) throw apiError;
+
       console.error('Error executing CaptchaKraken CLI:', error);
       if (error.stdout) console.log('CLI stdout on error:', error.stdout);
       if (error.stderr) console.error('CLI stderr on error:', error.stderr);

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,105 @@
+CaptchaKraken Source-Available License v1.0
+Copyright (c) 2026 JobHarvest / JWriter20. All rights reserved.
+
+This license governs use of the CaptchaKraken software in this repository and of
+the associated machine-learning model weights and LoRA adapters published by the
+copyright holder (collectively, the "Software"). By using the Software you agree
+to these terms. If you do not agree, do not use the Software.
+
+================================================================================
+1. GRANT
+================================================================================
+Subject to the restrictions below, you are granted a worldwide, royalty-free,
+non-exclusive license to use, copy, modify, and distribute the Software, and to
+incorporate it into your own products and services.
+
+================================================================================
+2. PERMITTED USES
+================================================================================
+You MAY use the Software for:
+
+  (a) Personal, non-commercial use, research, and education.
+
+  (b) Commercial use INSIDE a larger product or service that delivers
+      substantial value BEYOND captcha solving itself — that is, where captcha
+      solving is an internal, enabling component rather than the product.
+
+  Illustrative (non-exhaustive) examples of PERMITTED commercial use:
+      - Web scrapers and data-collection pipelines.
+      - Stealth / anti-detection browsers and browser automation frameworks
+        that use the Software as one internal capability.
+      - QA, testing, and accessibility tooling.
+      - Any application where the captcha solve is a means to an end the user
+        is actually paying for.
+
+================================================================================
+3. PROHIBITED USES
+================================================================================
+You MAY NOT, without a separate written commercial agreement from the copyright
+holder:
+
+  (a) Sell, resell, rent, or otherwise offer for a fee any captcha-SOLVING
+      service, product, or API whose primary value is solving captchas,
+      where that service is powered by the Software or its model outputs.
+
+  (b) Distribute "thin wrappers" around the Software whose primary purpose is
+      captcha solving — including but not limited to browser extensions,
+      hosted endpoints, SaaS products, or CLIs that simply expose the
+      Software's solving capability to end users.
+
+  (c) Expose, proxy, or relay the responses or outputs of the Software's LoRA
+      models (e.g. bounding boxes, tile selections, click plans) through a paid
+      or public API as a captcha-solving service.
+
+  In short: you may BUILD WITH this Software, but you may not SELL THE SOLVE.
+
+================================================================================
+4. MODEL OUTPUTS
+================================================================================
+Outputs produced by the model weights/adapters are subject to Sections 2 and 3
+to the same extent as the Software itself. Reselling or API-relaying those
+outputs as a captcha-solving service is prohibited under Section 3(c).
+
+================================================================================
+5. REDISTRIBUTION
+================================================================================
+If you redistribute the Software (modified or not), you must retain this license
+and this notice, and you must not remove or alter the restrictions in Section 3.
+
+================================================================================
+6. TRADEMARKS
+================================================================================
+This license does not grant permission to use the trade names, trademarks, or
+product names of the copyright holder, except as required to describe the origin
+of the Software.
+
+================================================================================
+7. NO WARRANTY
+================================================================================
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+8. RESPONSIBLE USE
+================================================================================
+You are responsible for ensuring your use of the Software complies with all
+applicable laws, the terms of service of any site you interact with, and
+applicable anti-fraud and computer-access statutes. The copyright holder does
+not endorse using the Software to violate any third party's terms or rights.
+
+================================================================================
+9. COMMERCIAL LICENSING
+================================================================================
+For uses prohibited under Section 3 — including selling captcha-solving as a
+service — contact the copyright holder to discuss a separate commercial license.
+
+--------------------------------------------------------------------------------
+This text is a license, not legal advice. If the boundary between a permitted
+"value-add" product and a prohibited "thin wrapper" is unclear for your use
+case, ask by opening an issue or messaging the maintainer on GitHub:
+https://github.com/JWriter20/CaptchaKraken
+--------------------------------------------------------------------------------

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,104 @@
+# captchakraken-mcp
+
+The CaptchaKraken account, driven from an MCP client. It signs you in through
+GitHub, mints and revokes API keys for the solving endpoint, and reads back what
+you have spent.
+
+**It does not solve captchas.** The key it mints is what does that, against the
+OpenAI-compatible endpoint at `api.captchakraken.com/v1`.
+
+```bash
+claude mcp add captchakraken -- npx -y captchakraken-mcp
+```
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `sign_in` | Prints a code and a link; the human approves in a browser. Creates the account if it does not exist, with trial credits and a first key. |
+| `sign_out` | Revokes this client's token on the server and deletes it from disk. |
+| `get_account` | Who is signed in, the balance, and the base URL to point a solver at. |
+| `get_balance` | The balance, and nothing else. |
+| `get_usage` | Billable responses and credits, per day and in total, plus purchases. |
+| `list_api_keys` | The account's solving keys, masked. |
+| `create_api_key` | Mints one. **The secret is returned once.** |
+| `revoke_api_key` | Kills one by id. Effective within ~30 seconds. |
+| `get_topup_link` | A Stripe URL for the human to open. Charges nothing. |
+| `get_pricing` | The rate card, and how many responses a captcha typically takes. |
+| `get_models` | The lineup, so an agent can decide whether to self-host instead. |
+
+## Signing in
+
+The MCP server runs on a laptop, inside an editor, with no browser it controls
+and nowhere for an OAuth redirect to land. It also cannot hold our GitHub client
+secret — it is distributed to customers, so anything baked into it is public.
+
+So it uses the device flow (RFC 8628):
+
+```
+sign_in  ──▶  "Open http://…/device?code=ABCD-EFGH, code ABCD-EFGH"
+                    │
+                    ├─ the human opens it, signs in with GitHub, approves
+                    │
+sign_in  ──▶  "Signed in as <login>. Balance: $0.50"
+```
+
+`sign_in` waits about 25 seconds and then hands control back rather than
+blocking — MCP clients time tool calls out, and a call killed mid-wait would
+strand the code. **Calling it again resumes the same request**; it does not
+print a second code at a human who is already looking at the first.
+
+## Two credentials, two blast radii
+
+The token this server holds (`ckm_…`) manages the account: it reads the balance
+and usage, mints and revokes API keys, and opens a checkout page. **It cannot
+solve a captcha.**
+
+An API key (`ck_live_…`) solves captchas. **It cannot manage the account** — the
+account API returns 401 for one, exactly as it does for a random string.
+
+That split is the point. If they were one credential, a key leaked from a
+scraper could mint its own replacements faster than anyone could revoke them,
+and the balance would stop being a bound on the damage. Either can be revoked
+from the dashboard.
+
+Nothing here can spend money. `get_topup_link` returns a URL; a person clicks
+it, on a page Stripe hosts. There is no tool that charges a card.
+
+## Where the token lives
+
+`~/.config/captchakraken/mcp.json`, mode 0600 in a 0700 directory, keyed by the
+control-plane origin — so rehearsing against a staging deployment and then
+running against production switches identity cleanly instead of presenting a
+staging token to production and 401ing with no explanation.
+
+It is not encrypted. A local secret encrypted with a local key is ceremony, not
+protection: whoever can read the file can read the key. The real defences are
+the file mode, the token's one-year expiry, and the dashboard's disconnect
+button.
+
+Delete the file to forget everything, or run `sign_out`, which also revokes the
+token server-side. Prefer `sign_out` — deleting the file alone leaves a live
+credential that nothing can reach to revoke.
+
+## Configuration
+
+| Variable | Default | Why |
+| --- | --- | --- |
+| `CAPTCHAKRAKEN_BASE_URL` | `https://captchakraken.com` | Point at a staging or self-hosted control plane. |
+| `CAPTCHAKRAKEN_CLIENT_NAME` | `MCP client` | Shown on the approval page. A person approving a code should see something they recognise. |
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm run build
+CAPTCHAKRAKEN_BASE_URL=http://127.0.0.1:3000 node dist/index.js
+```
+
+The server it talks to is `captchakraken-cloud`; the endpoints are documented in
+that package's README under **The MCP surface**, and covered by
+`test/mcp-api.test.ts` there. Nothing on stdout but MCP frames — stdout *is* the
+protocol channel on this transport, and one stray `console.log` corrupts the
+stream and presents as a broken server.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -21,7 +21,7 @@ claude mcp add captchakraken -- npx -y captchakraken-mcp
 | `get_balance` | The balance, and nothing else. |
 | `get_usage` | Billable responses and credits, per day and in total, plus purchases. |
 | `list_api_keys` | The account's solving keys, masked. |
-| `create_api_key` | Mints one. **The secret is returned once.** |
+| `create_api_key` | Mints one and **saves it to disk; the secret is never shown.** |
 | `revoke_api_key` | Kills one by id. Effective within ~30 seconds. |
 | `get_topup_link` | A Stripe URL for the human to open. Charges nothing. |
 | `get_pricing` | The rate card, and how many responses a captcha typically takes. |
@@ -65,12 +65,26 @@ from the dashboard.
 Nothing here can spend money. `get_topup_link` returns a URL; a person clicks
 it, on a page Stripe hosts. There is no tool that charges a card.
 
-## Where the token lives
+## Where the credentials live
 
-`~/.config/captchakraken/mcp.json`, mode 0600 in a 0700 directory, keyed by the
-control-plane origin — so rehearsing against a staging deployment and then
-running against production switches identity cleanly instead of presenting a
-staging token to production and 401ing with no explanation.
+Two files, because they are two credentials.
+
+**The management token** (`ckm_…`) is in `~/.config/captchakraken/mcp.json`,
+mode 0600 in a 0700 directory, keyed by the control-plane origin — so
+rehearsing against a staging deployment and then running against production
+switches identity cleanly instead of presenting a staging token to production
+and 401ing with no explanation.
+
+**The solving key** (`ck_live_…`) is in `~/.captchakraken/credentials`, also
+0600, written by `create_api_key` and read by the solver itself. It carries the
+endpoint alongside the key, so after `create_api_key` a solve works with **no
+environment variables set at all**.
+
+The secret is never returned through a tool result. It goes straight to that
+file and the tool reports the path, because a key in a tool result is a key in
+the transcript the moment an agent repeats it back in a summary — and asking an
+agent nicely not to do that is not a control. If you need the key in an env var
+instead, read it out of the file yourself; nothing in this server will print it.
 
 It is not encrypted. A local secret encrypted with a local key is ceremony, not
 protection: whoever can read the file can read the key. The real defences are

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1221 @@
+{
+  "name": "captchakraken-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "captchakraken-mcp",
+      "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "captchakraken-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "captchakraken-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for CaptchaKraken: sign in with GitHub, mint API keys for the Abyss model, and read your usage and spending.",
+  "type": "module",
+  "author": "Jake Writer",
+  "license": "SEE LICENSE IN LICENSE",
+  "bin": {
+    "captchakraken-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JWriter20/CaptchaKraken.git",
+    "directory": "mcp"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "captcha",
+    "captchakraken"
+  ],
+  "bugs": {
+    "url": "https://github.com/JWriter20/CaptchaKraken/issues"
+  },
+  "homepage": "https://github.com/JWriter20/CaptchaKraken#readme",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -1,0 +1,132 @@
+/**
+ * The HTTP client for `/api/v1` on the control plane.
+ *
+ * ONE PLACE THAT TALKS TO THE NETWORK, so the timeout, the error shape and the
+ * "your token stopped working" case are decided once. Every tool in server.ts
+ * goes through here and none of them calls `fetch`.
+ *
+ * ERRORS ARE THROWN AS `ApiError` WITH THE SERVER'S CODE INTACT. The control
+ * plane deliberately returns a stable `error` string and a human `message`; the
+ * message is what an agent shows a person, and the code is what the tools
+ * branch on. Flattening them into one string would mean parsing English to
+ * decide whether to prompt for a sign-in.
+ */
+
+import { loadCredential, saveCredential } from './credentials.js';
+
+/** Every request gets this long. A hung control plane must not hang the editor. */
+const TIMEOUT_MS = 20_000;
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export interface ApiOptions {
+  method?: 'GET' | 'POST';
+  body?: unknown;
+  /** Send the stored token. False for the device endpoints, which mint one. */
+  authenticated?: boolean;
+}
+
+export class ControlPlane {
+  readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  async request<T>(path: string, options: ApiOptions = {}): Promise<T> {
+    const { method = 'GET', body, authenticated = true } = options;
+
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      // Named so a support conversation can tell an MCP client apart from curl
+      // in an access log. It carries no authority.
+      'user-agent': 'captchakraken-mcp',
+    };
+    if (body !== undefined) headers['content-type'] = 'application/json';
+
+    if (authenticated) {
+      const credential = loadCredential(this.baseUrl);
+      if (!credential.accessToken) {
+        throw new ApiError(401, 'not_signed_in', 'Not signed in. Run the sign_in tool first.');
+      }
+      headers.authorization = `Bearer ${credential.accessToken}`;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      // A DNS failure, a refused connection and our own abort all land here, and
+      // they mean the same thing to the person reading it: we could not reach
+      // the service. The cause is included because "which one" is the first
+      // thing anyone debugging asks.
+      throw new ApiError(
+        0,
+        'network_error',
+        `Could not reach ${this.baseUrl}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const payload = await readJson(response);
+
+    if (!response.ok) {
+      const code = typeof payload?.error === 'string' ? payload.error : `http_${response.status}`;
+      const message =
+        typeof payload?.message === 'string'
+          ? payload.message
+          : `${this.baseUrl}${path} returned ${response.status}`;
+
+      /*
+       * A 401 on an authenticated call means the token we hold is dead —
+       * revoked from the dashboard, expired, or from a deployment this is no
+       * longer pointed at. Dropping it here is what turns the next `sign_in`
+       * into a clean new flow instead of a confusing "already signed in".
+       *
+       * Only on authenticated calls: the device endpoints answer 400/401 for
+       * reasons that have nothing to do with a stored token.
+       */
+      if (response.status === 401 && authenticated) {
+        const credential = loadCredential(this.baseUrl);
+        delete credential.accessToken;
+        delete credential.expiresAt;
+        saveCredential(this.baseUrl, credential);
+      }
+
+      throw new ApiError(response.status, code, message);
+    }
+
+    return payload as T;
+  }
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = await response.json();
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    // An HTML error page from a proxy in front of the app, most likely. The
+    // caller turns this into "returned <status>", which is more use than a JSON
+    // parse error nobody can act on.
+    return null;
+  }
+}

--- a/mcp/src/credentials.ts
+++ b/mcp/src/credentials.ts
@@ -1,0 +1,208 @@
+/**
+ * Where the token lives on disk.
+ *
+ * THIS FILE IS A CREDENTIAL, and it is written with that in mind: the directory
+ * is 0700, the file is 0600, and it is created with those modes rather than
+ * chmod'ed afterwards — a file that is briefly world-readable on a shared box is
+ * a file that was world-readable.
+ *
+ * IT IS KEYED BY BASE URL. Someone rehearsing against dev.captchakraken.com and
+ * then running against production must not have the dev token silently
+ * presented to production, where it is not a token at all and every call 401s
+ * with no explanation. So the store is a map from origin to what we hold for it,
+ * and switching `CAPTCHAKRAKEN_BASE_URL` switches identity cleanly.
+ *
+ * NOTHING HERE IS ENCRYPTED. A local secret encrypted with a local key is
+ * ceremony, not protection — whoever can read the file can read the key. The
+ * real defences are the file mode, the token's one-year expiry, and the
+ * dashboard's disconnect button.
+ */
+
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface StoredAccount {
+  userId: number;
+  githubLogin: string | null;
+  email: string | null;
+}
+
+/** A sign-in that has been started but not yet approved in the browser. */
+export interface PendingDevice {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete: string;
+  /** Epoch millis. Past this the code is dead and `sign_in` starts a new one. */
+  expiresAtMs: number;
+  intervalSeconds: number;
+}
+
+export interface Credential {
+  accessToken?: string;
+  /** ISO 8601, as returned by the control plane. */
+  expiresAt?: string;
+  account?: StoredAccount;
+  pending?: PendingDevice;
+}
+
+type Store = Record<string, Credential>;
+
+function configPath(): string {
+  // XDG first, because someone who has set it has done so on purpose. The
+  // fallback is ~/.config on every platform rather than %APPDATA% on Windows —
+  // one path is easier to tell a person to delete than three.
+  const base = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), '.config');
+  return join(base, 'captchakraken', 'mcp.json');
+}
+
+function readStore(): Store {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(configPath(), 'utf8'));
+    return parsed && typeof parsed === 'object' ? (parsed as Store) : {};
+  } catch {
+    // Missing, empty, or corrupt all mean the same thing to every caller: we
+    // hold nothing for this origin, so sign in. Refusing to start because the
+    // file has a stray comma would strand someone with no obvious way out.
+    return {};
+  }
+}
+
+function writeStore(store: Store): void {
+  const path = configPath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+
+  /*
+   * Write-then-rename, so a crash mid-write cannot leave a truncated file where
+   * a valid one was — the failure that would cost someone their token for no
+   * reason. The temporary file is created 0600 so the secret is never on disk
+   * under a laxer mode, even for the instant before the rename.
+   */
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+
+  // renameSync preserves the temporary file's mode, but an existing file's mode
+  // wins on some filesystems. Cheap to be sure.
+  chmodSync(path, 0o600);
+}
+
+export function credentialPath(): string {
+  return configPath();
+}
+
+/*
+ * ───────────────────────────────────────────────────────────────────────────
+ * The solver credential — a SECOND, deliberately separate store.
+ *
+ * Two credentials exist and they must never meet:
+ *
+ *   ckm_…      management token. Talks to the control plane's /api/v1. Lives in
+ *              mcp.json, above. Can mint and revoke keys.
+ *   ck_live_…  inference key. Talks to the gateway. Lives here. Can spend money
+ *              but cannot mint anything.
+ *
+ * Keeping them in one file would mean whatever reads the solver key at solve
+ * time is also holding a token that can issue more keys — a strictly worse
+ * blast radius for no gain. So this is a separate file in a separate directory,
+ * and the only thing that crosses between them is that `create_api_key` writes
+ * this one as a side effect.
+ *
+ * WHY A FILE AT ALL: `create_api_key` used to return the secret in its tool
+ * result, which puts a live inference key into the agent transcript — the
+ * exact thing this handoff exists to prevent. The key goes to disk at 0600 and
+ * the agent is told the path.
+ *
+ * The Python client reads this in `config.py` (`_read_credentials_file`), which
+ * accepts either name for each value; the env-file form is used because it is
+ * also directly `source`-able by a human.
+ * ───────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Where the solver looks for its key.
+ *
+ * `CAPTCHA_KRAKEN_STATE_DIR` is honoured because the Python client honours it —
+ * if the two disagreed, someone who had redirected their state dir would get a
+ * file written where nothing reads it and a 401 with no explanation.
+ */
+export function solverCredentialPath(): string {
+  const stateDir =
+    process.env.CAPTCHA_KRAKEN_STATE_DIR?.trim() || join(homedir(), '.captchakraken');
+  return join(stateDir, 'credentials');
+}
+
+/**
+ * Write the inference key and its endpoint where the solver will find them.
+ *
+ * The endpoint travels WITH the key on purpose: a hosted user who has never run
+ * vLLM has no reason to know what `VLLM_BASE_URL` is, and a key without an
+ * endpoint authenticates flawlessly against a local port with nothing behind
+ * it. Writing both means signup configures the solve path completely.
+ *
+ * Returns the path, which is what the caller reports in place of the secret.
+ */
+export function writeSolverCredential(options: {
+  apiKey: string;
+  baseUrl?: string;
+}): string {
+  const path = solverCredentialPath();
+
+  // 0700 on the directory, created with the mode rather than chmod'ed into it:
+  // a directory that is briefly world-readable is a directory that was
+  // world-readable, and the file inside it is a live credential.
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+
+  const lines = [
+    '# CaptchaKraken inference key — written by captchakraken-mcp.',
+    '# Keep this file private (0600). Revoke the key from the dashboard or the',
+    '# MCP `revoke_api_key` tool if it is ever exposed.',
+    `CAPTCHA_KRAKEN_API_KEY=${options.apiKey}`,
+  ];
+  if (options.baseUrl) lines.push(`VLLM_BASE_URL=${options.baseUrl}`);
+
+  // Write-then-rename through a 0600 temp file, so a crash mid-write cannot
+  // leave a truncated credential where a valid one was.
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${lines.join('\n')}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+
+  // renameSync preserves the temp file's mode, but an existing file's mode wins
+  // on some filesystems — and this path is very likely to already exist, since
+  // minting a second key overwrites the first. Cheap to be sure.
+  chmodSync(path, 0o600);
+
+  return path;
+}
+
+export function loadCredential(baseUrl: string): Credential {
+  return readStore()[baseUrl] ?? {};
+}
+
+export function saveCredential(baseUrl: string, credential: Credential): void {
+  const store = readStore();
+  store[baseUrl] = credential;
+  writeStore(store);
+}
+
+export function clearCredential(baseUrl: string): void {
+  const store = readStore();
+  delete store[baseUrl];
+  writeStore(store);
+}
+
+/**
+ * Is there a token, and is it still in date?
+ *
+ * The expiry is checked locally as a courtesy — the server checks it too, and
+ * the server is the one that decides. This exists so `sign_in` can say "your
+ * token expired" instead of the agent discovering it through a 401 on whatever
+ * it was actually trying to do.
+ */
+export function hasLiveToken(credential: Credential): boolean {
+  if (!credential.accessToken) return false;
+  if (!credential.expiresAt) return true;
+  const expiry = Date.parse(credential.expiresAt);
+  return Number.isNaN(expiry) || expiry > Date.now();
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * The entry point. Stdio transport, because that is what an editor speaks.
+ *
+ * NOTHING MAY BE WRITTEN TO STDOUT except MCP frames. Stdout *is* the protocol
+ * channel on this transport, and one stray `console.log` — a debug line, a
+ * deprecation notice, a banner — corrupts the stream and the client reports the
+ * server as broken rather than as chatty. Every diagnostic in this package goes
+ * to stderr, which the client shows in its logs.
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import { createServer } from './server.js';
+
+/**
+ * Which deployment to talk to.
+ *
+ * Overridable so the same package can be pointed at a staging box, and so a
+ * self-hosted control plane is a configuration line rather than a fork. The
+ * default is production, because that is what `npx captchakraken-mcp` with no
+ * arguments should mean.
+ */
+const BASE_URL = (process.env.CAPTCHAKRAKEN_BASE_URL ?? 'https://captchakraken.com').replace(
+  /\/$/,
+  '',
+);
+
+/**
+ * What the approval page calls this client.
+ *
+ * A person approving a code should see something they recognise, and "the thing
+ * I am typing in" is more recognisable than "captchakraken-mcp". Editors that
+ * set this are rare, so the fallback matters more than the variable.
+ */
+const CLIENT_NAME =
+  process.env.CAPTCHAKRAKEN_CLIENT_NAME?.trim() || 'MCP client';
+
+async function main(): Promise<void> {
+  const server = createServer(BASE_URL, CLIENT_NAME);
+  await server.connect(new StdioServerTransport());
+  console.error(`[captchakraken-mcp] connected, talking to ${BASE_URL}`);
+}
+
+main().catch((error: unknown) => {
+  console.error('[captchakraken-mcp] fatal:', error instanceof Error ? error.stack : error);
+  process.exit(1);
+});

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,780 @@
+/**
+ * The tools.
+ *
+ * WHAT THIS SERVER IS FOR: letting an agent provision and watch its own captcha
+ * solving. Sign the human in, mint a key for the Abyss model, report what has
+ * been spent, and hand over a payment link when the balance runs low. It does
+ * not solve captchas — that is the gateway's OpenAI-compatible endpoint, and
+ * the key minted here is what talks to it.
+ *
+ * TWO RULES SHAPE EVERY TOOL BELOW.
+ *
+ *  1. NOTHING SPENDS MONEY WITHOUT A HUMAN. `get_topup_link` returns a URL. It
+ *     does not charge a card, and there is no tool that can. An agent may
+ *     *offer* to spend; a person clicks.
+ *
+ *  2. NO TOOL OUTPUT EVER CONTAINS A LIVE CREDENTIAL. `create_api_key` writes
+ *     the minted key straight to a 0600 file and reports the PATH; the solver
+ *     reads it from there. Returning the secret — which this tool used to do —
+ *     puts it in the transcript the moment an agent repeats it in a summary,
+ *     and asking the agent nicely not to is not a control. The management
+ *     token obtained by `sign_in` is likewise written to disk and never
+ *     printed.
+ *
+ * Read-only tools are annotated as such so a client can decide what needs
+ * confirming. `create_api_key` and `revoke_api_key` are not read-only and are
+ * marked destructive where they are.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { ApiError, ControlPlane } from './api.js';
+import {
+  clearCredential,
+  credentialPath,
+  hasLiveToken,
+  loadCredential,
+  saveCredential,
+  solverCredentialPath,
+  writeSolverCredential,
+} from './credentials.js';
+import type { PendingDevice } from './credentials.js';
+
+/**
+ * How long `sign_in` waits before handing control back.
+ *
+ * Deliberately short. MCP clients time tool calls out — 60 seconds is a common
+ * default — and a sign-in that blocks for two minutes gets killed with the
+ * device code stranded. So this polls for well under any of them, then returns
+ * "still waiting, call me again", and the pending code is on disk so the next
+ * call resumes the same flow rather than printing a second code at a human who
+ * is already looking at the first one.
+ */
+const SIGN_IN_WAIT_MS = 25_000;
+
+interface DeviceStart {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface TokenGrant {
+  access_token: string;
+  expires_at: string;
+  account: {
+    user_id: number;
+    github_login: string | null;
+    email: string | null;
+    balance_credits: number;
+    balance_usd: string;
+  };
+}
+
+interface AccountResponse {
+  account: {
+    user_id: number;
+    github_login: string | null;
+    email: string | null;
+    created_at: string;
+    balance_credits: number;
+    balance_usd: string;
+    low_balance_threshold: number | null;
+    low_balance: boolean;
+  };
+  endpoint: { base_url: string; dashboard_url: string; requires_dev_header: boolean };
+  credits_per_usd: number;
+}
+
+interface UsageResponse {
+  window_days: number;
+  totals: {
+    billable_rounds: number;
+    credits: number;
+    usd: string;
+    waived_rounds: number;
+    by_client: Array<{ client: string | null; billable_rounds: number; credits: number }>;
+  };
+  daily: Array<{ day: string; billable_rounds: number; credits: number }>;
+  recent: Array<{
+    at: string;
+    puzzle_class: string;
+    credits: number;
+    waived_reason: string | null;
+    client: string | null;
+    upstream_ms: number | null;
+  }>;
+  ledger: Array<{ at: string; kind: string; delta_credits: number; usd_amount_cents: number | null }>;
+  balance_credits: number;
+  balance_usd: string;
+}
+
+interface KeyListResponse {
+  max_active_keys: number;
+  keys: Array<{
+    id: number;
+    name: string | null;
+    masked: string;
+    created_at: string;
+    last_used_at: string | null;
+    revoked: boolean;
+  }>;
+}
+
+interface CreatedKeyResponse {
+  id: number;
+  api_key: string;
+  masked: string;
+  name: string | null;
+  base_url: string;
+}
+
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+};
+
+function text(body: string): ToolResult {
+  return { content: [{ type: 'text', text: body }] };
+}
+
+function failure(body: string): ToolResult {
+  return { content: [{ type: 'text', text: body }], isError: true };
+}
+
+/**
+ * Turn a thrown ApiError into something an agent can act on.
+ *
+ * `not_signed_in` gets the instruction rather than the raw message, because it
+ * is the one failure with an obvious next step and an agent that is told the
+ * step will take it instead of reporting an error to the human.
+ */
+function describe(error: unknown): ToolResult {
+  if (error instanceof ApiError) {
+    if (error.code === 'not_signed_in' || error.status === 401) {
+      return failure('Not signed in to CaptchaKraken. Run the `sign_in` tool first.');
+    }
+    return failure(`${error.code}: ${error.message}`);
+  }
+  return failure(error instanceof Error ? error.message : String(error));
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function createServer(baseUrl: string, clientName: string): McpServer {
+  const api = new ControlPlane(baseUrl);
+  const server = new McpServer(
+    { name: 'captchakraken', version: '0.1.0' },
+    {
+      instructions:
+        'CaptchaKraken account management. Use sign_in once to connect a GitHub account, ' +
+        'create_api_key to get a key for the captcha-solving endpoint, and get_usage / ' +
+        'get_balance to see what has been spent. This server does not solve captchas itself — ' +
+        'the key it mints is used against the OpenAI-compatible endpoint reported by get_account.',
+    },
+  );
+
+  // ── signing in ────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'sign_in',
+    {
+      title: 'Sign in to CaptchaKraken',
+      description:
+        'Connect a CaptchaKraken account using GitHub, creating one if it does not exist. ' +
+        'Prints a short code and a link for the human to approve in a browser, then waits ' +
+        'briefly. If it returns still-waiting, call it again to resume the same sign-in — it ' +
+        'will not start a second one. New accounts get free trial credits and a first API key.',
+      inputSchema: {
+        client_name: z
+          .string()
+          .optional()
+          .describe('Name shown on the approval page, e.g. the editor this is running in.'),
+      },
+      annotations: { title: 'Sign in to CaptchaKraken', openWorldHint: true },
+    },
+    async ({ client_name }) => {
+      try {
+        const credential = loadCredential(baseUrl);
+
+        if (hasLiveToken(credential)) {
+          const who = credential.account?.githubLogin ?? `account ${credential.account?.userId}`;
+          return text(
+            `Already signed in as ${who} on ${baseUrl}.\n` +
+              'Run `sign_out` first if you want to connect a different account.',
+          );
+        }
+
+        // Resume a code that is still live rather than printing a second one at
+        // a human who is already looking at the first.
+        let pending = credential.pending;
+        if (!pending || pending.expiresAtMs <= Date.now()) {
+          const started = await api.request<DeviceStart>('/api/v1/device/start', {
+            method: 'POST',
+            authenticated: false,
+            body: { client_name: client_name ?? clientName },
+          });
+          pending = {
+            deviceCode: started.device_code,
+            userCode: started.user_code,
+            verificationUri: started.verification_uri,
+            verificationUriComplete: started.verification_uri_complete,
+            expiresAtMs: Date.now() + started.expires_in * 1000,
+            intervalSeconds: started.interval,
+          };
+          saveCredential(baseUrl, { ...credential, pending });
+        }
+
+        const outcome = await pollForToken(api, pending);
+
+        if (outcome.kind === 'granted') {
+          saveCredential(baseUrl, {
+            accessToken: outcome.grant.access_token,
+            expiresAt: outcome.grant.expires_at,
+            account: {
+              userId: outcome.grant.account.user_id,
+              githubLogin: outcome.grant.account.github_login,
+              email: outcome.grant.account.email,
+            },
+          });
+          const who = outcome.grant.account.github_login ?? `account ${outcome.grant.account.user_id}`;
+          return text(
+            `Signed in as ${who}.\n` +
+              `Balance: ${outcome.grant.account.balance_usd} (${outcome.grant.account.balance_credits.toLocaleString('en-US')} credits).\n` +
+              `The token is stored at ${credentialPath()} and can be revoked from the dashboard at any time.\n\n` +
+              'Next: `create_api_key` mints a key for the solving endpoint.',
+          );
+        }
+
+        if (outcome.kind === 'waiting') {
+          return text(
+            `Waiting for approval.\n\n` +
+              `  Open:  ${pending.verificationUriComplete}\n` +
+              `  Code:  ${pending.userCode}\n\n` +
+              'Ask the human to open that link and approve the code. Then call `sign_in` again ' +
+              'to resume — it will pick up this same request, not start a new one.',
+          );
+        }
+
+        // Denied or dead. Drop the pending code so the next call starts clean.
+        const { pending: _dropped, ...withoutPending } = credential;
+        saveCredential(baseUrl, withoutPending);
+        return failure(
+          outcome.kind === 'denied'
+            ? 'The sign-in was declined in the browser. Nothing was connected.'
+            : 'That sign-in code expired or was already used. Call `sign_in` again for a new one.',
+        );
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sign_out',
+    {
+      title: 'Sign out',
+      description:
+        'Revoke this client’s access token on the server and delete it from disk. API keys ' +
+        'already minted keep working — this disconnects the management client, not the solving.',
+      annotations: { title: 'Sign out', destructiveHint: true, openWorldHint: true },
+    },
+    async () => {
+      try {
+        // Revoke server-side first. If that fails we still have the token, and
+        // deleting it locally would leave a live credential nobody can reach to
+        // revoke — the file is the only copy of it.
+        await api.request('/api/v1/signout', { method: 'POST' });
+        clearCredential(baseUrl);
+        return text('Signed out. The token has been revoked on the server and removed from disk.');
+      } catch (error) {
+        if (error instanceof ApiError && (error.status === 401 || error.code === 'not_signed_in')) {
+          clearCredential(baseUrl);
+          return text('There was no live token. Local state cleared.');
+        }
+        return describe(error);
+      }
+    },
+  );
+
+  // ── the account ───────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'get_account',
+    {
+      title: 'Account and endpoint',
+      description:
+        'Who is signed in, the credit balance, and the base URL to point an OpenAI-compatible ' +
+        'client at for solving.',
+      annotations: { title: 'Account and endpoint', readOnlyHint: true, openWorldHint: true },
+    },
+    async () => {
+      try {
+        const me = await api.request<AccountResponse>('/api/v1/me');
+        const lines = [
+          `Account:   ${me.account.github_login ?? `#${me.account.user_id}`}`,
+          `Email:     ${me.account.email ?? '(none on file)'}`,
+          `Balance:   ${me.account.balance_usd} (${me.account.balance_credits.toLocaleString('en-US')} credits)`,
+          `Endpoint:  ${me.endpoint.base_url}`,
+          `Dashboard: ${me.endpoint.dashboard_url}`,
+        ];
+        if (me.account.low_balance) {
+          lines.push('', 'Balance is low. `get_topup_link` returns a payment link for the human.');
+        }
+        if (me.endpoint.requires_dev_header) {
+          lines.push(
+            '',
+            'This is a development deployment: its gateway also requires the shared X-CK-Dev-Auth header in front of the key.',
+          );
+        }
+        return text(lines.join('\n'));
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_balance',
+    {
+      title: 'Credit balance',
+      description: 'The remaining credit balance, in credits and in dollars. Nothing else.',
+      annotations: { title: 'Credit balance', readOnlyHint: true, openWorldHint: true },
+    },
+    async () => {
+      try {
+        const me = await api.request<AccountResponse>('/api/v1/me');
+        return text(
+          `${me.account.balance_usd} (${me.account.balance_credits.toLocaleString('en-US')} credits)` +
+            (me.account.low_balance ? ' — low' : ''),
+        );
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_usage',
+    {
+      title: 'Usage and spending',
+      description:
+        'Billable inference responses and credits spent, per day and in total, plus recent ' +
+        'purchases. The server keeps a rolling 30-day window; `days` narrows what is reported.',
+      inputSchema: {
+        days: z
+          .number()
+          .int()
+          .min(1)
+          .max(30)
+          .optional()
+          .describe('How many of the last 30 days to report. Defaults to all 30.'),
+      },
+      annotations: { title: 'Usage and spending', readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ days }) => {
+      try {
+        const usage = await api.request<UsageResponse>('/api/v1/usage');
+
+        // Sliced here rather than asked for: the window is fixed server-side
+        // because that is what makes the read cheap. See the note on the route.
+        const window = days ?? usage.window_days;
+        const daily = usage.daily.slice(-window);
+        const credits = daily.reduce((sum, day) => sum + day.credits, 0);
+        const rounds = daily.reduce((sum, day) => sum + day.billable_rounds, 0);
+
+        const lines = [
+          `Last ${window} day${window === 1 ? '' : 's'}:`,
+          `  ${rounds.toLocaleString('en-US')} billable responses`,
+          `  ${credits.toLocaleString('en-US')} credits spent`,
+          `Balance now: ${usage.balance_usd} (${usage.balance_credits.toLocaleString('en-US')} credits)`,
+        ];
+
+        if (usage.totals.waived_rounds > 0) {
+          lines.push(
+            '',
+            `${usage.totals.waived_rounds} response(s) in the full window were served free — our own retries and the per-attempt cap. Those are not billing errors.`,
+          );
+        }
+
+        if (usage.totals.by_client.length > 1) {
+          lines.push('', 'By integration (full window):');
+          for (const row of usage.totals.by_client) {
+            lines.push(
+              `  ${row.client ?? 'direct'}: ${row.billable_rounds.toLocaleString('en-US')} rounds, ${row.credits.toLocaleString('en-US')} credits`,
+            );
+          }
+        }
+
+        const spending = daily.filter((day) => day.credits > 0);
+        if (spending.length > 0) {
+          lines.push('', 'Per day:');
+          for (const day of spending) {
+            lines.push(`  ${day.day}  ${day.credits.toLocaleString('en-US')} credits`);
+          }
+        }
+
+        if (usage.ledger.length > 0) {
+          lines.push('', 'Purchases and grants:');
+          for (const entry of usage.ledger.slice(0, 10)) {
+            const paid =
+              entry.usd_amount_cents === null ? '' : ` ($${(entry.usd_amount_cents / 100).toFixed(2)})`;
+            lines.push(
+              `  ${entry.at.slice(0, 10)}  ${entry.kind}  ${entry.delta_credits > 0 ? '+' : ''}${entry.delta_credits.toLocaleString('en-US')}${paid}`,
+            );
+          }
+        }
+
+        return text(lines.join('\n'));
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  // ── keys ──────────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'list_api_keys',
+    {
+      title: 'List API keys',
+      description:
+        'The account’s solving keys, masked. The secret half is not stored anywhere and cannot ' +
+        'be listed — only minted.',
+      annotations: { title: 'List API keys', readOnlyHint: true, openWorldHint: true },
+    },
+    async () => {
+      try {
+        const listing = await api.request<KeyListResponse>('/api/v1/keys');
+        if (listing.keys.length === 0) {
+          return text('No keys yet. `create_api_key` mints one.');
+        }
+        const rows = listing.keys.map((key) => {
+          const state = key.revoked ? 'revoked' : 'live';
+          const used = key.last_used_at ? `last used ${key.last_used_at.slice(0, 10)}` : 'never used';
+          return `  #${key.id}  ${key.masked}  ${key.name ?? '(unnamed)'}  [${state}, ${used}]`;
+        });
+        const live = listing.keys.filter((key) => !key.revoked).length;
+        return text(
+          [`${live} live of ${listing.max_active_keys} allowed:`, ...rows].join('\n'),
+        );
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'create_api_key',
+    {
+      title: 'Create an API key',
+      description:
+        'Mint a key for the captcha-solving endpoint (the Abyss model) and save it to disk where ' +
+        'the solver will find it. THE SECRET IS NEVER RETURNED — it is written straight to a ' +
+        '0600 file and only the path is reported back, so it cannot leak through this ' +
+        'conversation. After this runs, a solve works with no environment variables set.',
+      inputSchema: {
+        name: z
+          .string()
+          .max(60)
+          .optional()
+          .describe('A label so this key is identifiable in the dashboard, e.g. "scraper-prod".'),
+      },
+      annotations: { title: 'Create an API key', readOnlyHint: false, openWorldHint: true },
+    },
+    async ({ name }) => {
+      try {
+        const created = await api.request<CreatedKeyResponse>('/api/v1/keys', {
+          method: 'POST',
+          body: { name: name ?? null },
+        });
+
+        // The secret goes to disk and NOT into this tool's result. Everything
+        // returned below is safe to repeat: an id, a masked form, and a path.
+        //
+        // The write is the last thing that can fail, and if it does the key
+        // already exists server-side — so say so plainly rather than pretending
+        // nothing happened, and point at revoke. Silently swallowing this would
+        // strand a live key that the user does not know they own.
+        let credentialFile: string;
+        try {
+          credentialFile = writeSolverCredential({
+            apiKey: created.api_key,
+            baseUrl: created.base_url,
+          });
+        } catch (writeError) {
+          const reason = writeError instanceof Error ? writeError.message : String(writeError);
+          return text(
+            [
+              `Key #${created.id} was created (${created.masked}), but saving it to ` +
+                `${solverCredentialPath()} failed: ${reason}`,
+              '',
+              'The secret is NOT being printed here — it would end up in this transcript.',
+              'The key exists server-side and cannot be retrieved again, so either fix the',
+              `permissions on that path and mint a new key, or revoke key #${created.id} with`,
+              'revoke_api_key so nothing untracked is left live.',
+            ].join('\n'),
+          );
+        }
+
+        return text(
+          [
+            `Key #${created.id} created${created.name ? ` (${created.name})` : ''}, shown as ${created.masked} in the dashboard.`,
+            '',
+            `Saved to ${credentialFile} (0600), pointing at ${created.base_url}.`,
+            '',
+            'The secret itself is deliberately not shown — it went straight to that file so it',
+            'never enters this conversation, and only a SHA-256 is stored server-side. Solving',
+            'now works with no environment variables set at all.',
+          ].join('\n'),
+        );
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'revoke_api_key',
+    {
+      title: 'Revoke an API key',
+      description:
+        'Kill a key by its id. It stops working within about 30 seconds — the gateway’s refresh ' +
+        'interval. This cannot be undone; mint a new key instead of trying to restore one.',
+      inputSchema: {
+        id: z.number().int().positive().describe('The key id from list_api_keys.'),
+      },
+      annotations: { title: 'Revoke an API key', readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+    },
+    async ({ id }) => {
+      try {
+        await api.request(`/api/v1/keys/${id}/revoke`, { method: 'POST' });
+        return text(`Key #${id} revoked. It stops working within 30 seconds.`);
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  // ── money ─────────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'get_topup_link',
+    {
+      title: 'Get a top-up link',
+      description:
+        'A URL the human opens to add credits. THIS DOES NOT CHARGE ANYTHING — it returns a ' +
+        'link; a person completes the payment on Stripe. Omit `usd` to let them choose the ' +
+        'amount, which is the right default when the agent has not been told what to spend.',
+      inputSchema: {
+        usd: z
+          .number()
+          .positive()
+          .optional()
+          .describe('A published pack amount. Omit to return the chooser page instead.'),
+      },
+      annotations: { title: 'Get a top-up link', readOnlyHint: false, openWorldHint: true },
+    },
+    async ({ usd }) => {
+      try {
+        const result = await api.request<{
+          url: string;
+          kind: 'chooser' | 'checkout';
+          usd?: number;
+          credits?: number;
+          packs?: Array<{ usd: number; credits: number }>;
+        }>('/api/v1/billing/checkout', {
+          method: 'POST',
+          body: usd === undefined ? {} : { usd },
+        });
+
+        if (result.kind === 'checkout') {
+          return text(
+            `Stripe checkout for $${result.usd} (${result.credits?.toLocaleString('en-US')} credits):\n\n  ${result.url}\n\n` +
+              'Nothing has been charged. The human completes the payment on that page, and the credits land within seconds of it succeeding.',
+          );
+        }
+
+        const packs = (result.packs ?? [])
+          .map((pack) => `  $${pack.usd} → ${pack.credits.toLocaleString('en-US')} credits`)
+          .join('\n');
+        return text(
+          `Top-up page:\n\n  ${result.url}\n\nAvailable packs:\n${packs}\n\nNothing has been charged.`,
+        );
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_pricing',
+    {
+      title: 'Pricing',
+      description:
+        'The rate card: dollars per 1,000 inference responses for images and for video, how many ' +
+        'responses a captcha typically takes, and the per-captcha billing ceiling. Use this to ' +
+        'estimate a job before running it.',
+      annotations: { title: 'Pricing', readOnlyHint: true, openWorldHint: true },
+    },
+    async () => {
+      try {
+        const pricing = await api.request<{
+          credits_per_usd: number;
+          max_billable_responses_per_session: number;
+          max_responses_per_session: number;
+          free_challenges: string[];
+          classes: Array<{
+            puzzle_class: string;
+            label: string;
+            covers: string;
+            credits_per_response: number;
+            usd_per_1000_responses: number;
+            typical_responses_per_captcha: string;
+          }>;
+          credit_packs: Array<{ usd: number; credits: number }>;
+        }>('/api/v1/pricing', { authenticated: false });
+
+        const lines = [
+          `Billed per inference response. $1.00 = ${pricing.credits_per_usd.toLocaleString('en-US')} credits.`,
+          '',
+        ];
+        for (const row of pricing.classes) {
+          lines.push(
+            `${row.label}: $${row.usd_per_1000_responses.toFixed(2)} per 1,000 (${row.credits_per_response} credits each)`,
+            `  ${row.covers}`,
+            // The number that turns a rate into a cost. Without it an agent
+            // estimating a job would quietly assume one response per captcha.
+            `  Typically ${row.typical_responses_per_captcha} response(s) per captcha`,
+          );
+        }
+        lines.push(
+          '',
+          `Free (never reach the model): ${pricing.free_challenges.join(', ')}`,
+          // The ceiling an agent should actually plan against: one captcha can
+          // never cost more than this, however badly it goes.
+          `One captcha costs at most ${pricing.max_billable_responses_per_session} billable responses ` +
+            `($${((pricing.classes.find((row) => row.puzzle_class === 'image')?.usd_per_1000_responses ?? 0) * pricing.max_billable_responses_per_session).toFixed(2)} per 1,000 for images). ` +
+            `Responses past that are served free, and the attempt is abandoned after ${pricing.max_responses_per_session}.`,
+          `Packs: ${pricing.credit_packs.map((pack) => `$${pack.usd}`).join(', ')}`,
+        );
+        return text(lines.join('\n'));
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_models',
+    {
+      title: 'Models',
+      description:
+        'The model lineup: which weights can be self-hosted, and which one the hosted endpoint ' +
+        'runs. Useful for deciding whether to pay per solve or run it yourself.',
+      annotations: { title: 'Models', readOnlyHint: true, openWorldHint: true },
+    },
+    async () => {
+      try {
+        const listing = await api.request<{
+          base_url: string;
+          models: Array<{
+            name: string;
+            zone: string;
+            tagline: string;
+            hosted: boolean;
+            hugging_face_id: string | null;
+            published: boolean;
+            min_vram: string | null;
+            weights_gb: number | null;
+            accuracy: number | null;
+            video: boolean;
+          }>;
+        }>('/api/v1/models', { authenticated: false });
+
+        const lines = [`Hosted endpoint: ${listing.base_url}`, ''];
+        for (const model of listing.models) {
+          lines.push(`${model.name} — ${model.zone}`);
+          lines.push(`  ${model.tagline}`);
+          lines.push(
+            model.hosted
+              ? '  Hosted only; not downloadable.'
+              : model.published
+                ? `  Weights: ${model.hugging_face_id} (~${model.weights_gb} GB, needs ${model.min_vram})`
+                : `  Weights: ${model.hugging_face_id} — reserved, not uploaded yet`,
+          );
+          if (model.accuracy !== null) {
+            lines.push(`  Measured: ${(model.accuracy * 100).toFixed(1)}% exact match`);
+          }
+          if (model.video) lines.push('  Handles video challenges.');
+          lines.push('');
+        }
+        return text(lines.join('\n').trimEnd());
+      } catch (error) {
+        return describe(error);
+      }
+    },
+  );
+
+  return server;
+}
+
+type PollOutcome =
+  | { kind: 'granted'; grant: TokenGrant }
+  | { kind: 'waiting' }
+  | { kind: 'denied' }
+  | { kind: 'dead' };
+
+/**
+ * Poll until the token arrives or the budget runs out.
+ *
+ * `slow_down` doubles the interval, permanently for this attempt, which is what
+ * RFC 8628 §3.5 asks for. It should not happen — we honour the interval the
+ * server gave us — but a clock that jumps or a retried call can produce it, and
+ * an implementation that ignores it is one that hammers an unauthenticated
+ * endpoint whenever it does.
+ */
+async function pollForToken(api: ControlPlane, pending: PendingDevice): Promise<PollOutcome> {
+  const deadline = Date.now() + SIGN_IN_WAIT_MS;
+  let interval = Math.max(1, pending.intervalSeconds) * 1000;
+
+  while (Date.now() < deadline) {
+    if (pending.expiresAtMs <= Date.now()) return { kind: 'dead' };
+
+    try {
+      const grant = await api.request<TokenGrant>('/api/v1/device/token', {
+        method: 'POST',
+        authenticated: false,
+        body: { device_code: pending.deviceCode },
+      });
+      return { kind: 'granted', grant };
+    } catch (error) {
+      if (!(error instanceof ApiError)) throw error;
+
+      switch (error.code) {
+        case 'authorization_pending':
+          break;
+        case 'slow_down':
+          interval *= 2;
+          break;
+        case 'access_denied':
+          return { kind: 'denied' };
+        case 'expired_token':
+          return { kind: 'dead' };
+        default:
+          throw error;
+      }
+    }
+
+    // Do not overshoot the deadline sleeping: returning a moment early with
+    // "call me again" is better than being killed by the client's timeout.
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(interval, remaining));
+  }
+
+  return { kind: 'waiting' };
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "declaration": false,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "captchakraken"
-version = "2.3.0"
+version = "2.4.0"
 description = "Self-hosted captcha solver: OpenCV grid detection + a fine-tuned Qwen3.5-9B vision LoRA served on vLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/captchakraken/cli.py
+++ b/python/src/captchakraken/cli.py
@@ -56,6 +56,7 @@ import os
 import subprocess
 import sys
 
+from .errors import CaptchaKrakenAPIError
 from .solver import CaptchaSolver, UnsupportedCaptchaError
 from .timing import timed
 
@@ -707,6 +708,17 @@ def main():
         # checkboxes. Emit a clean error with no traceback.
         print(json.dumps({"error": str(e), "unsupported": True}), file=sys.stderr)
         sys.exit(2)
+    except CaptchaKrakenAPIError as e:
+        # The hosted API refused us and told us why. That is an answer, not a
+        # crash, so no traceback: a stack trace here buries the one line the
+        # user needs ("out of credits, top up at …") under frames from a module
+        # they have never opened.
+        #
+        # Exit 3, distinct from 1 (genuine failure) and 2 (unsupported puzzle),
+        # and the payload carries the machine-readable fields so the JS driver
+        # can rebuild the error rather than regex it out of prose.
+        print(json.dumps(e.to_payload()), file=sys.stderr)
+        sys.exit(3)
     except Exception as e:
         import traceback
 

--- a/python/src/captchakraken/config.py
+++ b/python/src/captchakraken/config.py
@@ -47,8 +47,31 @@ def pinned() -> Dict[str, Any]:
 
 # ── Inference endpoint ──────────────────────────────────────────────────────
 def base_url() -> str:
-    """OpenAI-compatible endpoint, e.g. http://localhost:8000/v1."""
-    return os.getenv("VLLM_BASE_URL", f"http://localhost:{port()}/v1")
+    """OpenAI-compatible endpoint, e.g. http://localhost:8000/v1.
+
+    Precedence mirrors `api_key()` exactly — env, then the credentials file,
+    then the local default — because the two values are set together and a
+    reader who has learned one ordering should not have to learn a second.
+
+      1. VLLM_BASE_URL. An explicit override always wins; self-hosters and the
+         dev environment depend on this and must not be silently redirected.
+      2. The credentials file. Written by the MCP signup flow alongside the key,
+         so onboarding configures the endpoint in the same step and a hosted
+         user needs no env plumbing at all.
+      3. localhost. Unchanged, and still correct: someone with no credentials
+         file is by definition not a hosted user, so the self-hosted default is
+         the right guess for them.
+
+    The bug this closes: a camoufox user who signed up through the MCP had a
+    valid key and no endpoint, so every solve dialled a local port with nothing
+    behind it and failed with connection-refused — a message that says nothing
+    about the fact that their requests were meant to go to api.captchakraken.com.
+    """
+    return (
+        os.getenv("VLLM_BASE_URL")
+        or _base_url_from_credentials_file()
+        or f"http://localhost:{port()}/v1"
+    )
 
 
 def state_dir() -> Path:
@@ -60,36 +83,81 @@ def credentials_path() -> Path:
     return state_dir() / "credentials"
 
 
-def _key_from_credentials_file() -> str:
-    """Key written by the MCP server's signup flow (or a future `login` command).
+# Names the credentials file may use for each value. Two spellings each, because
+# the file doubles as something a user can `source` — the VLLM_* names are the
+# env vars this module already honours, and the CAPTCHA_KRAKEN_* names are what
+# the product calls them. Accepting both costs nothing and spares anyone the
+# discovery that they picked the wrong one.
+_KEY_NAMES = ("CAPTCHA_KRAKEN_API_KEY", "VLLM_API_KEY")
+_BASE_URL_NAMES = ("CAPTCHA_KRAKEN_BASE_URL", "VLLM_BASE_URL")
+
+
+def _read_credentials_file() -> Dict[str, str]:
+    """Parse the file the MCP server's signup flow writes.
 
     Hosted-API onboarding writes the key to a 0600 file rather than returning it
     through the agent transcript, so it never lands in an LLM context window.
     Reading it here is what lets a solve authenticate with NO env vars set.
 
-    Deliberately tolerant of a bare token, an env-file line, or surrounding
-    quotes: the file is written by a *separate* tool, and a format mismatch here
-    would surface as a baffling 401 rather than an obvious parse error.
-    Returns "" whenever the file is missing, unreadable, or has no usable line.
+    Returns a mapping of recognised name -> value. The special key ``""`` holds a
+    BARE TOKEN — a file containing nothing but `ck_live_…`, which is what the
+    original single-value format was and what a user hand-writing this file is
+    most likely to produce. Dropping that would silently break every existing
+    credentials file, so it is still accepted and still means "the API key".
+
+    Deliberately tolerant of quoting and comments: the file is written by a
+    *separate* tool, and a format mismatch here surfaces as a baffling 401
+    rather than an obvious parse error. Returns {} whenever the file is missing
+    or unreadable — the self-hosted case, which must stay silent.
     """
     try:
         text = credentials_path().read_text(encoding="utf-8")
     except OSError:
-        return ""
+        return {}
 
+    found: Dict[str, str] = {}
     for line in text.splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
         if "=" in line:
             name, _, value = line.partition("=")
+            name = name.strip()
             # An env-file with unrelated keys must not yield a bogus token.
-            if name.strip() not in {"CAPTCHA_KRAKEN_API_KEY", "VLLM_API_KEY"}:
+            if name not in _KEY_NAMES and name not in _BASE_URL_NAMES:
                 continue
-            line = value.strip()
-        return line.strip("'\"")
+            found.setdefault(name, value.strip().strip("'\""))
+        elif "" not in found:
+            # A bare token. Only the first such line counts; later prose in a
+            # hand-edited file must not overwrite the credential.
+            found[""] = line.strip("'\"")
 
+    return found
+
+
+def _first_present(values: Dict[str, str], names) -> str:
+    """First non-empty value among `names`, in the order given."""
+    for name in names:
+        value = values.get(name, "").strip()
+        if value:
+            return value
     return ""
+
+
+def _key_from_credentials_file() -> str:
+    """The API key from the credentials file, or "" if there isn't one."""
+    values = _read_credentials_file()
+    return _first_present(values, _KEY_NAMES) or values.get("", "").strip()
+
+
+def _base_url_from_credentials_file() -> str:
+    """The endpoint from the credentials file, or "" if it names none.
+
+    A bare-token file deliberately yields nothing here: it carries no endpoint,
+    and inventing the hosted one for it would silently redirect a self-hoster
+    who wrote a token into that file by hand.
+    """
+    return _first_present(_read_credentials_file(), _BASE_URL_NAMES)
 
 
 def api_key() -> str:

--- a/python/src/captchakraken/errors.py
+++ b/python/src/captchakraken/errors.py
@@ -1,0 +1,195 @@
+"""What the hosted API's refusals mean, in words a user can act on.
+
+The solver talks to an OpenAI-compatible endpoint that may be a local vLLM the
+user started themselves or the hosted CaptchaKraken gateway. Those two fail very
+differently, and until this module existed both were reported the same way:
+`vLLM 402 Payment Required at https://api.captchakraken.com/v1/chat/completions`.
+A camoufox user who has never heard of vLLM, run vLLM, or intended to run vLLM
+would hit that on the day their credits ran out.
+
+Two rules, both inherited from the gateway's own `src/errors.ts`:
+
+ 1. BRANCH ON `error.code`, NEVER ON PROSE. The messages get reworded; the codes
+    are the contract. A client that pattern-matches "Out of credits" breaks the
+    day someone improves the wording.
+
+ 2. AN UNRECOGNISED CODE MUST STILL PRODUCE A USEFUL MESSAGE. There are ten
+    codes today and there will be more. Enumerating them exhaustively here means
+    the eleventh is reported worse than the ten — so the fallback carries the
+    server's own `message` and `resolution_url` through, and only the phrasing
+    is lost.
+
+The self-hosted path is deliberately untouched: a local vLLM does not send this
+envelope, so `from_response` returns a message shaped like the old one and the
+401/403 hint about the bearer token survives. Nobody self-hosting sees a word
+about credits.
+"""
+
+from typing import Any, Dict, Optional
+
+# Where a user with no `resolution_url` in hand should be sent. Only used as a
+# fallback — the server almost always supplies a deep link that is better than
+# this, and when it does we prefer it.
+_DASHBOARD = "https://captchakraken.com/dashboard"
+_SUPPORT = "https://captchakraken.com/support"
+
+
+class CaptchaKrakenAPIError(RuntimeError):
+    """A refusal from the hosted API, already translated.
+
+    Carries the machine-readable parts alongside the message so a caller that
+    wants to react programmatically (retry on `rate_limited`, stop on
+    `insufficient_credits`) can do so without re-parsing anything. `str(e)` is
+    the human sentence and is what reaches a console.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[int] = None,
+        code: Optional[str] = None,
+        resolution_url: Optional[str] = None,
+        retry_after_seconds: Optional[float] = None,
+    ):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.resolution_url = resolution_url
+        self.retry_after_seconds = retry_after_seconds
+
+    def to_payload(self) -> Dict[str, Any]:
+        """The shape the CLI puts on stderr for the JS driver to pick up.
+
+        The JS half shells out to this CLI and can only see stdout/stderr, so
+        the structured fields would otherwise be flattened to a string at the
+        process boundary and have to be re-parsed out of prose — exactly the
+        thing rule 1 forbids.
+        """
+        return {
+            "error": str(self),
+            "ck_error": {
+                "status": self.status,
+                "code": self.code,
+                "resolution_url": self.resolution_url,
+                "retry_after_seconds": self.retry_after_seconds,
+            },
+        }
+
+
+def _retry_after(headers: Any) -> Optional[float]:
+    """Seconds from the `Retry-After` header, if it is the numeric form.
+
+    HTTP also permits an HTTP-date here. The gateway only ever sends deltas, and
+    guessing wrong about a date would produce a confidently incorrect "wait 3
+    seconds", so anything unparseable is dropped rather than approximated.
+    """
+    try:
+        raw = headers.get("Retry-After")
+    except Exception:  # noqa: BLE001 — a mapping-ish object is all we assume
+        return None
+    if raw is None:
+        return None
+    try:
+        return float(str(raw).strip())
+    except ValueError:
+        return None
+
+
+def _sentence(code: str, message: str, url: Optional[str], retry: Optional[float]) -> str:
+    """The user-facing line for a known code.
+
+    Every branch names CaptchaKraken. That is the entire point of this module:
+    the person reading it needs to know which product is refusing them before
+    anything else in the sentence can help.
+    """
+    if code == "insufficient_credits":
+        return (
+            "CaptchaKraken: your account is out of credits, so this solve was refused. "
+            f"Top up at {url or _DASHBOARD} and retry."
+        )
+
+    if code == "solve_abandoned":
+        return (
+            "CaptchaKraken: this captcha attempt was served too many times without "
+            "settling and has been abandoned. That usually means the IP reputation or "
+            "the browser fingerprint is being rejected — not that the answers were "
+            "wrong. Start a fresh attempt with a new x-ck-session (the driver mints "
+            "one per solve() call, so a new solve is enough)."
+        )
+
+    if code == "rate_limited":
+        wait = f" Retry in about {retry:g}s." if retry else " Back off and retry."
+        return f"CaptchaKraken: too many requests.{wait}"
+
+    if code == "account_suspended":
+        return (
+            "CaptchaKraken: this account is suspended, so solving is disabled. "
+            f"Contact support at {url or _SUPPORT}."
+        )
+
+    if code == "request_too_large":
+        return (
+            "CaptchaKraken: the screenshot sent for this solve exceeded the request "
+            f"size limit. ({message}) Capture the captcha element rather than the "
+            "whole page if you are not already."
+        )
+
+    if code in ("missing_api_key", "invalid_api_key"):
+        return (
+            "CaptchaKraken: the API key was missing or not accepted. Set "
+            "CAPTCHA_KRAKEN_API_KEY, or run the CaptchaKraken MCP server's "
+            "`create_api_key` tool to write one to ~/.captchakraken/credentials. "
+            f"Manage keys at {url or _DASHBOARD}."
+        )
+
+    if code == "upstream_unavailable":
+        return (
+            "CaptchaKraken: the solver fleet is temporarily unreachable. This is on "
+            "our side, not yours — retry shortly."
+        )
+
+    # `unrecognized_prompt`, `invalid_request`, and anything added after this was
+    # written. The server's own message is the best thing available, so it is
+    # carried through verbatim rather than replaced with a guess.
+    tail = f" See {url}." if url else ""
+    return f"CaptchaKraken: {message}{tail}"
+
+
+def from_response(resp: Any, url: str) -> Exception:
+    """Build the exception for a non-OK response, hosted or self-hosted.
+
+    Returns rather than raises so the caller's `raise` keeps the traceback
+    anchored at the request site, where it is useful.
+    """
+    body_text = (getattr(resp, "text", "") or "")[:300]
+    status = getattr(resp, "status_code", None)
+
+    error: Dict[str, Any] = {}
+    try:
+        parsed = resp.json()
+        if isinstance(parsed, dict) and isinstance(parsed.get("error"), dict):
+            error = parsed["error"]
+    except Exception:  # noqa: BLE001 — a non-JSON body is the self-hosted case
+        error = {}
+
+    code = error.get("code")
+    if isinstance(code, str) and code:
+        retry = _retry_after(getattr(resp, "headers", {}) or {})
+        resolution = error.get("resolution_url") or None
+        message = str(error.get("message") or "").strip() or "the request was refused"
+        return CaptchaKrakenAPIError(
+            _sentence(code, message, resolution, retry),
+            status=status,
+            code=code,
+            resolution_url=resolution,
+            retry_after_seconds=retry,
+        )
+
+    # No gateway envelope: a local vLLM, a proxy in between, or an HTML error
+    # page. Keep the pre-existing message so self-hosted debugging is unchanged.
+    hint = ""
+    if status in (401, 403):
+        hint = " — check CAPTCHA_KRAKEN_API_KEY is set and forwarded to the CLI"
+    reason = getattr(resp, "reason", "") or ""
+    return RuntimeError(f"vLLM {status} {reason} at {url}{hint}. Body: {body_text}")

--- a/python/src/captchakraken/planner.py
+++ b/python/src/captchakraken/planner.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from . import config
+from . import config, errors
 from .server_manager import ensure_server
 from .timing import timed
 
@@ -288,21 +288,18 @@ class ActionPlanner:
         with timed("planner.chat"):
             resp = requests.post(url, headers=headers, json=payload, timeout=120)
 
-        # Surface auth / server errors with the actual body instead of letting
-        # resp.json() blow up with a cryptic "Expecting value: line 1 column 1"
-        # on a non-JSON response (e.g. a 401 {"error":"Unauthorized"} or an
-        # HTML error page). 401/403 almost always means the bearer token
-        # (CAPTCHA_KRAKEN_API_KEY) didn't reach this process.
+        # Surface auth / billing / server errors as something the reader can act
+        # on, instead of letting resp.json() blow up with a cryptic "Expecting
+        # value: line 1 column 1" on a non-JSON response.
+        #
+        # `errors.from_response` decides which of the two worlds we are in by
+        # looking for the gateway's `error.code`: present means the hosted API
+        # refused us and there is a real explanation to give (out of credits,
+        # rate limited, attempt abandoned); absent means a local vLLM or a proxy,
+        # and the old message — including the bearer-token hint on 401/403 — is
+        # reproduced unchanged.
         if not resp.ok:
-            body = (resp.text or "")[:300]
-            hint = ""
-            if resp.status_code in (401, 403):
-                hint = (
-                    " — check CAPTCHA_KRAKEN_API_KEY is set and forwarded to the CLI"
-                )
-            raise RuntimeError(
-                f"vLLM {resp.status_code} {resp.reason} at {url}{hint}. Body: {body}"
-            )
+            raise errors.from_response(resp, url)
 
         try:
             data = resp.json()

--- a/python/tests/test_api_errors.py
+++ b/python/tests/test_api_errors.py
@@ -1,0 +1,228 @@
+"""The hosted API's refusals must read as CaptchaKraken problems, not vLLM ones.
+
+Before this existed, a camoufox user whose credits ran out saw:
+
+    vLLM 402 Payment Required at https://api.captchakraken.com/v1/chat/completions
+
+naming a piece of infrastructure they had never installed and giving them
+nothing to do about it. These tests pin the two properties that fix matters for:
+
+  * a hosted refusal names CaptchaKraken and, where one exists, the URL that
+    resolves it;
+  * a SELF-HOSTED failure is untouched — no mention of credits or dashboards to
+    someone running their own vLLM, and the bearer-token hint on 401/403 that
+    was there before is still there.
+
+Hermetic: a stub response object stands in for `requests`. Asserting against a
+live zero-balance account would need a live zero-balance account, which is both
+awkward to keep and a test of the server rather than of this client.
+"""
+import json
+
+import pytest
+
+from captchakraken import errors
+from captchakraken.errors import CaptchaKrakenAPIError
+
+
+class FakeResponse:
+    """The slice of `requests.Response` that `from_response` actually reads."""
+
+    def __init__(self, status_code, payload=None, *, text=None, headers=None, reason=""):
+        self.status_code = status_code
+        self.reason = reason
+        self.headers = headers or {}
+        self._payload = payload
+        self.text = text if text is not None else json.dumps(payload or {})
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no JSON body")
+        return self._payload
+
+
+def gateway(status, code, message, *, resolution_url=None, headers=None, reason=""):
+    """A response shaped like the gateway's OpenAI-style error envelope."""
+    error = {"message": message, "type": "billing_error", "code": code}
+    if resolution_url:
+        error["resolution_url"] = resolution_url
+    return FakeResponse(status, {"error": error}, headers=headers, reason=reason)
+
+
+# ── The headline case: out of credits ───────────────────────────────────────
+def test_402_names_the_product_and_the_top_up_url():
+    resp = gateway(
+        402,
+        "insufficient_credits",
+        "Out of credits. Top up to resume solving.",
+        resolution_url="https://captchakraken.com/billing",
+    )
+    exc = errors.from_response(resp, "https://api.captchakraken.com/v1/chat/completions")
+
+    assert isinstance(exc, CaptchaKrakenAPIError)
+    message = str(exc)
+    assert "CaptchaKraken" in message
+    assert "https://captchakraken.com/billing" in message
+    # The whole point: the user must not be told about vLLM.
+    assert "vLLM" not in message
+    assert exc.code == "insufficient_credits"
+    assert exc.status == 402
+    assert exc.resolution_url == "https://captchakraken.com/billing"
+
+
+def test_402_without_a_resolution_url_still_points_somewhere():
+    exc = errors.from_response(
+        gateway(402, "insufficient_credits", "Out of credits."), "http://x/v1/chat/completions"
+    )
+    assert "captchakraken.com" in str(exc)
+
+
+# ── The other four a real user hits ─────────────────────────────────────────
+def test_409_solve_abandoned_blames_fingerprint_not_the_answers():
+    exc = errors.from_response(
+        gateway(409, "solve_abandoned", "…served 10 times…"), "http://x/v1/chat/completions"
+    )
+    message = str(exc)
+    assert "CaptchaKraken" in message
+    # The actionable half: it is almost never the model's answers.
+    assert "fingerprint" in message
+    assert "x-ck-session" in message
+    assert exc.code == "solve_abandoned"
+
+
+def test_429_honours_retry_after():
+    exc = errors.from_response(
+        gateway(429, "rate_limited", "Too many requests.", headers={"Retry-After": "30"}),
+        "http://x/v1/chat/completions",
+    )
+    assert exc.retry_after_seconds == 30
+    assert "30s" in str(exc)
+
+
+def test_429_without_retry_after_does_not_invent_one():
+    exc = errors.from_response(
+        gateway(429, "rate_limited", "Too many requests."), "http://x/v1/chat/completions"
+    )
+    assert exc.retry_after_seconds is None
+    assert "Back off" in str(exc)
+
+
+def test_retry_after_http_date_is_dropped_rather_than_guessed():
+    # A confidently wrong "wait 3 seconds" is worse than saying nothing.
+    exc = errors.from_response(
+        gateway(
+            429,
+            "rate_limited",
+            "Too many requests.",
+            headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+        ),
+        "http://x/v1/chat/completions",
+    )
+    assert exc.retry_after_seconds is None
+
+
+def test_403_account_suspended_points_at_support():
+    exc = errors.from_response(
+        gateway(
+            403,
+            "account_suspended",
+            "This account is suspended.",
+            resolution_url="https://captchakraken.com/support",
+        ),
+        "http://x/v1/chat/completions",
+    )
+    assert "suspended" in str(exc)
+    assert "https://captchakraken.com/support" in str(exc)
+    assert exc.code == "account_suspended"
+
+
+def test_413_request_too_large_suggests_the_fix():
+    exc = errors.from_response(
+        gateway(413, "request_too_large", "Request body exceeds the 8000000-byte limit."),
+        "http://x/v1/chat/completions",
+    )
+    assert "CaptchaKraken" in str(exc)
+    assert "captcha element" in str(exc)
+
+
+def test_401_invalid_key_mentions_the_mcp_path():
+    # Someone onboarded through the MCP has no env var to check, so pointing
+    # only at CAPTCHA_KRAKEN_API_KEY would send them looking in the wrong place.
+    exc = errors.from_response(
+        gateway(401, "invalid_api_key", "Invalid API key."), "http://x/v1/chat/completions"
+    )
+    assert "create_api_key" in str(exc)
+    assert "~/.captchakraken/credentials" in str(exc)
+
+
+# ── Forward compatibility ───────────────────────────────────────────────────
+def test_an_unknown_code_carries_the_servers_own_message_through():
+    # The eleventh code must not be reported worse than the ten known ones.
+    exc = errors.from_response(
+        gateway(
+            400,
+            "some_code_invented_next_year",
+            "The widget frobnicator is misaligned.",
+            resolution_url="https://captchakraken.com/docs/frob",
+        ),
+        "http://x/v1/chat/completions",
+    )
+    assert isinstance(exc, CaptchaKrakenAPIError)
+    assert "The widget frobnicator is misaligned." in str(exc)
+    assert "https://captchakraken.com/docs/frob" in str(exc)
+    assert exc.code == "some_code_invented_next_year"
+
+
+# ── The self-hosted path must not regress ───────────────────────────────────
+def test_a_plain_vllm_500_keeps_the_old_message():
+    resp = FakeResponse(500, None, text="Internal Server Error", reason="Internal Server Error")
+    exc = errors.from_response(resp, "http://localhost:8000/v1/chat/completions")
+
+    assert not isinstance(exc, CaptchaKrakenAPIError)
+    message = str(exc)
+    assert "vLLM 500" in message
+    assert "http://localhost:8000/v1/chat/completions" in message
+    # Nobody self-hosting should be told to top up an account.
+    assert "credits" not in message
+
+
+def test_a_plain_vllm_401_keeps_the_bearer_token_hint():
+    resp = FakeResponse(401, None, text='{"error":"Unauthorized"}', reason="Unauthorized")
+    exc = errors.from_response(resp, "http://localhost:8000/v1/chat/completions")
+    assert not isinstance(exc, CaptchaKrakenAPIError)
+    assert "CAPTCHA_KRAKEN_API_KEY" in str(exc)
+
+
+def test_an_html_error_page_does_not_crash_the_parser():
+    # A proxy in front of a local server returns HTML, not JSON. `resp.json()`
+    # raising must degrade to the generic message, not propagate.
+    resp = FakeResponse(502, None, text="<html><body>Bad Gateway</body></html>", reason="Bad Gateway")
+    exc = errors.from_response(resp, "http://localhost:8000/v1/chat/completions")
+    assert not isinstance(exc, CaptchaKrakenAPIError)
+    assert "vLLM 502" in str(exc)
+
+
+def test_json_without_an_error_object_is_treated_as_self_hosted():
+    resp = FakeResponse(400, {"detail": "something else entirely"}, reason="Bad Request")
+    exc = errors.from_response(resp, "http://localhost:8000/v1/chat/completions")
+    assert not isinstance(exc, CaptchaKrakenAPIError)
+
+
+# ── The CLI/JS boundary ─────────────────────────────────────────────────────
+def test_payload_round_trips_the_machine_readable_fields():
+    # The JS driver rebuilds the error from exactly this; losing a field here
+    # means camoufox users lose the top-up link.
+    exc = CaptchaKrakenAPIError(
+        "CaptchaKraken: out of credits.",
+        status=402,
+        code="insufficient_credits",
+        resolution_url="https://captchakraken.com/billing",
+        retry_after_seconds=None,
+    )
+    payload = exc.to_payload()
+    assert payload["error"] == "CaptchaKraken: out of credits."
+    assert payload["ck_error"]["code"] == "insufficient_credits"
+    assert payload["ck_error"]["status"] == 402
+    assert payload["ck_error"]["resolution_url"] == "https://captchakraken.com/billing"
+    # Must survive json.dumps — it is written to stderr as one line.
+    assert json.loads(json.dumps(payload)) == payload

--- a/python/tests/test_credentials_file.py
+++ b/python/tests/test_credentials_file.py
@@ -85,3 +85,78 @@ def test_unreadable_file_degrades_to_empty(creds, tmp_path):
 def test_credentials_path_follows_the_state_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("CAPTCHA_KRAKEN_STATE_DIR", str(tmp_path))
     assert config.credentials_path() == tmp_path / "credentials"
+
+
+# ── The endpoint travels with the key ───────────────────────────────────────
+#
+# A key without an endpoint is useless to a hosted user: they authenticate
+# perfectly against localhost, where nothing is listening. So the MCP writes
+# both, and these pin that reading the pair back cannot redirect a self-hoster.
+
+
+@pytest.fixture
+def endpoint(tmp_path, monkeypatch):
+    """As `creds`, but also clears VLLM_BASE_URL so the file is what decides."""
+    monkeypatch.setenv("CAPTCHA_KRAKEN_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    monkeypatch.delenv("CAPTCHA_KRAKEN_API_KEY", raising=False)
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+
+    def write(text: str):
+        (tmp_path / "credentials").write_text(text, encoding="utf-8")
+
+    return write
+
+
+def test_no_file_still_defaults_to_localhost(endpoint):
+    # The self-hosting default. Changing this would break every existing user
+    # who runs their own vLLM and has never seen a credentials file.
+    assert config.base_url().startswith("http://localhost:")
+
+
+def test_file_supplies_the_hosted_endpoint(endpoint):
+    endpoint(
+        "CAPTCHA_KRAKEN_API_KEY=ck_live_abc\n"
+        "VLLM_BASE_URL=https://api.captchakraken.com/v1\n"
+    )
+    assert config.base_url() == "https://api.captchakraken.com/v1"
+    # …and the key still resolves from the same file, unchanged.
+    assert config.api_key() == "ck_live_abc"
+
+
+def test_the_product_spelling_of_the_base_url_is_accepted_too(endpoint):
+    endpoint("CAPTCHA_KRAKEN_BASE_URL=https://api.captchakraken.com/v1\n")
+    assert config.base_url() == "https://api.captchakraken.com/v1"
+
+
+def test_explicit_env_base_url_wins_over_the_file(endpoint, monkeypatch):
+    # Without this, pointing the dev environment at a staging endpoint would be
+    # silently ignored whenever a credentials file happened to exist.
+    endpoint("VLLM_BASE_URL=https://api.captchakraken.com/v1\n")
+    monkeypatch.setenv("VLLM_BASE_URL", "http://localhost:9999/v1")
+    assert config.base_url() == "http://localhost:9999/v1"
+
+
+def test_a_bare_token_file_does_not_redirect_anyone(endpoint):
+    # A bare token carries no endpoint. Inferring the hosted one from "there is
+    # a file" would hijack a self-hoster who hand-wrote their local key here.
+    endpoint("ck_live_abc123\n")
+    assert config.api_key() == "ck_live_abc123"
+    assert config.base_url().startswith("http://localhost:")
+
+
+def test_quotes_and_comments_are_tolerated_on_the_url_too(endpoint):
+    endpoint('# written by captchakraken-mcp\n\nVLLM_BASE_URL="https://api.captchakraken.com/v1"\n')
+    assert config.base_url() == "https://api.captchakraken.com/v1"
+
+
+def test_unreadable_file_still_defaults_to_localhost(endpoint, tmp_path):
+    (tmp_path / "credentials").mkdir()
+    assert config.base_url().startswith("http://localhost:")
+
+
+def test_a_later_bare_line_cannot_clobber_the_real_credential(endpoint):
+    # Hand-edited files pick up stray prose. The first bare line is the token;
+    # a trailing note must not replace it with garbage.
+    endpoint("ck_live_real\nsome stray note\n")
+    assert config.api_key() == "ck_live_real"


### PR DESCRIPTION
Cuts **2.4.0** for npm + PyPI and publishes **captchakraken-mcp 0.1.0** as a new package.

The theme: a camoufox user who signed up through the MCP and has never run vLLM could not actually get a solve to work, and could not find out why.

### What was broken

| | Before | After |
|---|---|---|
| Out of credits | `vLLM 402 Payment Required at https://api.captchakraken.com/...` | A sentence naming CaptchaKraken and the top-up URL |
| Minted key | Returned in the `create_api_key` tool result → into the agent transcript | Written to `~/.captchakraken/credentials` at 0600; only the path is reported |
| Endpoint | Defaulted to `localhost:8000` — connection-refused for hosted users | Travels with the key in the credentials file |
| MCP server | Not in any git repo, not on npm, `npx captchakraken-mcp` didn't work | `mcp/` workspace, CI-gated, published from this repo |

### Deliberately unchanged

Self-hosting. A local vLLM sends no error envelope, so it still gets the old message and bearer-token hint. A bare-token credentials file yields no endpoint, so nobody who hand-wrote a local key into that file gets silently redirected at our servers. Both are pinned by tests.

### Notes

- **New coupling:** `publish.yml` calls `ci.yml` as its verify step, and `ci.yml` now builds `mcp/`. A broken MCP blocks a client release. Right trade, but new.
- The MCP CI job runs a real MCP handshake against the built binary — a server that compiles but can't answer `tools/list` would otherwise ship green, and the likeliest cause (a stray write to stdout, which *is* the protocol channel) is invisible to `tsc`.
- `mcp/` stays at 0.1.0 on its own version line.
- **First publish of `captchakraken-mcp` needs a one-off manual `npm publish`** — npm's trusted-publisher config lives on the package page, which doesn't exist yet. Every release after is tokenless.
- Animated/video captcha solving that was sitting uncommitted in the working tree is held out of this release on `feat/animated-video-solving`; it has no tests of its own and hasn't been live-tested.

+23 tests (272 passed). Both ports typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)