### PR TITLE
Documentation that matches the code, and two things it was describing wrongly

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -13,10 +13,17 @@
  * stdout, which IS the protocol channel: one stray console.log corrupts every
  * frame. This catches both.
  *
+ * It also checks the version the server ADVERTISES against the one in
+ * package.json. That is not cosmetic: `serverInfo.version` is what an MCP
+ * client logs and reports in a bug, and the two had already drifted — the
+ * server said 0.1.0 while npm published 0.1.2. A literal that nothing compares
+ * to anything has no way of staying right.
+ *
  * Hermetic: tools/list is answered before any sign-in, so no credentials, no
  * network, and nothing to clean up.
  */
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 const cmd = process.argv[2];
 const args = process.argv.slice(3);
@@ -57,6 +64,16 @@ try {
     clientInfo: { name: 'smoke', version: '0.0.0' },
   });
   console.log('initialize OK — server:', JSON.stringify(init.result?.serverInfo));
+
+  // Run from the package directory, so package.json is the one being served.
+  const declared = JSON.parse(readFileSync('package.json', 'utf8')).version;
+  const advertised = init.result?.serverInfo?.version;
+  if (advertised !== declared) {
+    throw new Error(
+      `serverInfo.version is ${advertised} but package.json says ${declared} — ` +
+        'the version an MCP client sees must be the version that shipped',
+    );
+  }
 
   send({ jsonrpc: '2.0', method: 'notifications/initialized' });
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,8 +364,14 @@ client unless you have a reason not to.
 
 ## Rules for agents
 
-- **Never invent accuracy numbers.** Published figures are being re-measured.
-  Say they are not published yet.
+- **Never invent accuracy numbers.** The only figures we publish are the
+  recorded end-to-end solves in the
+  [README](./README.md#watch-it-work) — each puzzle driven on the vendor's own
+  demo page, quoted as counts rather than percentages, with the date and the
+  adapter beside them. Quote those or quote nothing. One row there is marked
+  **not scored**; do not turn it into a number. There is no published per-type
+  model-accuracy table, so do not produce one, derive one, or convert a count
+  into a percentage.
 - **Abyss is not serving yet** and is never downloadable. Do not tell a user
   the hosted API runs it, and do not suggest weights or a workaround for it.
   The hosted endpoint answers with **Twilight v1.2**. Verify with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@ drive a phone, and no way to turn it off when your stack already did it.
 - **`startingMousePosition` is now honoured on the first gesture too.** The
   camoufox origin-seeding step used to overwrite it with the window centre.
 
+### Fixed
+
+- **`captchakraken.__version__` said `2.6.0` while 2.6.1 was on PyPI and npm.**
+  Nothing compared it against the manifest pip actually reads, so every caller
+  branching on it — and every bug report quoting it — named a release that was
+  not the one running. Now checked by a test.
+
+- **`CaptchaKrakenAPIError` is exported from the Python package root**, as it
+  already was from the TypeScript one. `docs/hosted-api.md` tells every caller
+  to branch on its `.code`, and that recipe did not work in one of the two
+  languages the docs claim parity for: the type existed only at
+  `captchakraken.errors`. Purely additive — the old import path still works, and
+  `errors` imports nothing but `typing`, so this adds no dependency floor.
+
 ### Changed
 
 - **The pointer position moved out of the solver** and into the humanizer, in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ drive a phone, and no way to turn it off when your stack already did it.
   branching on it — and every bug report quoting it — named a release that was
   not the one running. Now checked by a test.
 
+- **The MCP server told every client it was `0.1.0`** while npm published
+  `0.1.2`. `serverInfo.version` is what an MCP client logs and what a user
+  quotes in a bug report, so the drift pointed every report at the wrong
+  release. The CI handshake smoke now compares the advertised version against
+  `package.json` and fails the build on a mismatch — the literal had nothing
+  comparing it to anything, which is why it drifted twice without notice.
+
 - **`CaptchaKrakenAPIError` is exported from the Python package root**, as it
   already was from the TypeScript one. `docs/hosted-api.md` tells every caller
   to branch on its `.code`, and that recipe did not work in one of the two

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,12 @@ To run a solver against a model you'll need a vLLM server — see
 
 ## Tests & CI
 
-CI runs a small, fast suite on every PR (no GPU, no network) — primarily the
-**grid-detection** checks in the Python port (`python/`), which are the
-foundation of the whole solve, plus a TypeScript build of the driver. Run them
-locally before opening a PR:
+Two gates run on every PR.
+
+**1. A hermetic suite** (no GPU, no network): the whole Python `pytest` suite —
+primarily the **grid-detection** checks in `python/`, which are the foundation
+of the whole solve — plus a TypeScript build of the driver. Run it locally
+before opening a PR:
 
 ```bash
 # Python: find_grid / grid-detection unit tests (fast, deterministic)
@@ -63,27 +65,40 @@ cd js
 npx tsc --noEmit -p tsconfig.json
 ```
 
-This package has **no browser end-to-end tests of its own** — it never launches a
-browser. The live solve-and-record tests (`record_demos.spec.ts` et al.) live in
-the parent `CaptchaKrakenFinetune` repo, which owns a Playwright launcher and
-drives the built solver. Grid detection is exercised by the Python tests above.
+**2. A driver gate.** Both ports are driven end to end through a real browser
+against a fixture suite, and the result comes back as the `tier3/driver-gate`
+commit status plus a PR comment with per-port and per-vendor pass rates. The
+fixtures and the model live in a private repo, so this one runs there and
+reports back — you cannot run it locally, and you do not need to. It is the gate
+that catches what a type-check cannot: a selector that moved, a click landing
+off-widget, or one port asking for something the other does not.
+
+This package has **no browser tests of its own** — it never launches a browser,
+and it ships none. Everything you can run locally is the hermetic suite above.
+
+> On a **fork PR** the driver gate cannot run: GitHub does not expose the
+> dispatch secret to a fork's workflow, so the check sits as pending. That is
+> expected. A maintainer re-runs it by pushing your branch into this repo.
 
 ## Pull requests
 
-- Branch off `main`, keep PRs focused, and describe what you changed and how you
-  verified it.
+- **Branch off `dev`, and open your PR against `dev`.** `main` is the release
+  branch and only ever takes a `dev` → `main` merge, so a PR straight into
+  `main` will be redirected.
+- Keep PRs focused, and describe what you changed and how you verified it.
 - If you touched grid detection, paste the `test_find_grid_corpus.py` per-type
   table before/after so reviewers can see the delta.
-- New end-to-end solving capability? Include a short clip or the
-  `record_demos_summary.json` numbers from a local run of the demo recorder in
-  the parent `CaptchaKrakenFinetune` repo
-  (`npx playwright test tests/record_demos.spec.ts` there).
+- New end-to-end solving capability? Say which vendor and puzzle it covers and
+  how you drove it. The driver gate above will exercise it; you do not need to
+  produce your own recording.
 
 ## What we'd love help with
 
 - More **real labeled samples** for under-represented hCaptcha grid prompts.
 - Robustness on **reCAPTCHA 4×4** (our weakest grid type end-to-end).
-- Out-of-scope puzzle types (drag/path/tetris) — currently detected and skipped.
+- Accuracy on the **freehand hCaptcha puzzles** — connect-the-path, the
+  numbered-line and missing-piece drags. Every hCaptcha family now routes and is
+  driven; these are the ones where the model is least reliable.
 - Smaller / faster quantizations so lower-VRAM hardware can self-host.
 
 Questions? Open an issue. Please don't open PRs that add a paid captcha-solving

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ neither is one we could not classify — only rounds where a challenge was on
 screen and had to be solved.
 
 One row is marked **not scored**. hCaptcha deals its drag puzzle too rarely for
-us to have collected a scored run of it, so that clip is a demonstration and the
-figures beside it are an estimate rather than a measurement. It is labelled
-where it appears rather than quietly averaged in with the rest.
+us to have collected a scored run of it, so that clip is a demonstration and
+carries no count or median at all. It is labelled where it appears rather than
+given numbers that would look exactly like the measured ones.
 
 <details open>
 <summary><b>hCaptcha</b> — 4 puzzle types</summary>

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@
 ## Watch it work
 
 Thirteen puzzle types, each driven on the vendor's own **public demo page**
-through the hosted API, with every attempt scored. These are the same clips that
-run on [captchakraken.com](https://captchakraken.com) — recorded 2026-08-19
-against **captcha-v12**.
+through the hosted API. Twelve of the thirteen had every attempt scored; the one
+that did not is marked. These are the same clips that run on
+[captchakraken.com](https://captchakraken.com) — recorded 2026-08-19 against
+**captcha-v12**, the adapter the hosted API serves today.
 
 Three things worth knowing before you read the numbers:
 
@@ -65,6 +66,11 @@ Three things worth knowing before you read the numbers:
 A round the vendor waved through without a puzzle is not in these counts, and
 neither is one we could not classify — only rounds where a challenge was on
 screen and had to be solved.
+
+One row is marked **not scored**. hCaptcha deals its drag puzzle too rarely for
+us to have collected a scored run of it, so that clip is a demonstration and the
+figures beside it are an estimate rather than a measurement. It is labelled
+where it appears rather than quietly averaged in with the rest.
 
 <details open>
 <summary><b>hCaptcha</b> — 4 puzzle types</summary>
@@ -85,9 +91,11 @@ One picture instead of tiles: click or drag the pieces the prompt names. hCaptch
   <a href="https://captchakraken.com/#demos">Watch the hCaptcha canvas puzzle solve</a>
 </video>
 
-**Drag puzzle** — 9/10 solved · 9.0s median
+**Drag puzzle** — ⚠️ *not scored — see above*
 
-Pick a character up and carry it to its match hidden behind the lines. hCaptcha deals this one rarely.
+Pick a character up and carry it to its match hidden behind the lines. hCaptcha
+deals this one so rarely we have not been able to record a scored run of it. The
+clip is real; there is no count or median to publish beside it yet.
 
 <video src="https://captchakraken.com/art/demo/hcaptcha_truedrag.webm" width="520" controls muted loop playsinline preload="none">
   <a href="https://captchakraken.com/#demos">Watch the hCaptcha drag puzzle solve</a>
@@ -362,16 +370,26 @@ set, so they are the likeliest to move.
 
 ### Accuracy, measured
 
-> 🔬 **Being re-measured.** The figures previously published here were taken on
-> 2026-07-27 under an eval split that let some hand-labeled captures reach
-> training, so they measured memorisation as well as skill. That split was
-> replaced — **every** real capture is now held out and nothing hand-labeled
-> trains — and the numbers are being re-taken against the new held-out set on
-> the next full training run. Rather than restate figures we no longer stand
-> behind, this section is blank until that lands.
+**The numbers we publish are the clips at the top of this page.** Each one is
+that puzzle driven on the vendor's own public demo page through the hosted API,
+with every attempt scored — counts, not percentages, and a median solve time
+computed from the run rather than from the footage. Recorded 2026-08-19 against
+`captcha-v12`, the adapter the hosted API serves today.
 
-What the measurement will be, so you can hold us to it: exact set match — every
-correct tile and no incorrect ones, no partial credit, because a
+That is deliberately the *end-to-end* number: detect, read, click, verify, and
+the vendor accepting. It is the one you can hold us to, because it is the one
+you experience.
+
+An earlier revision of this section carried per-type **model** accuracy taken on
+2026-07-27. Those figures were withdrawn — the eval split of the day let some
+hand-labeled captures reach training, so they measured memorisation alongside
+skill. The split was replaced (**every** real capture is held out; nothing
+hand-labeled trains) and the model has been re-measured against it since, but we
+are not restating a bare model-accuracy percentage here: on its own it tells you
+very little about whether a captcha clears. The clips do.
+
+The method behind them, so you can reproduce the shape of it: exact set match —
+every correct tile and no incorrect ones, no partial credit, because a
 partially-correct grid answer is a rejected captcha — taken over the full
 customer path (HTTPS → gateway → vLLM) rather than a local checkpoint, against
 captures the adapter has never trained on.
@@ -578,7 +596,11 @@ Most of the detail lives in the docs hub — start at **[docs/](./docs/README.md
   animated challenges, typed text — as a LoRA and as **Sunlight** / **Twilight**
   merges, all public on [HuggingFace](https://huggingface.co/CaptchaKraken).
 - 🟡 **In progress** — **Abyss**, the next hosted-only model.
-- ⚪ **Planned** — 🧩 more non-grid hCaptcha puzzles (drag, path, tetris-fit).
+- ⚪ **Planned** — 🎯 higher accuracy on the **freehand hCaptcha puzzles**
+  (connect-the-path and the numbered-line / missing-piece drags), which are the
+  families the model is least reliable on. Every hCaptcha family we ship is
+  already routed and driven — this is about how often they land, not whether
+  they are attempted.
 
 The visual, always-current version is in **[docs/roadmap.md](./docs/roadmap.md)**.
 📣 **[Watch the repo](https://github.com/JWriter20/CaptchaKraken)** to hear about

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,15 @@ CaptchaKraken detects the captcha, solves it, clicks, and verifies.
 | ✅ **hCaptcha 3×3 image grid** | Works end-to-end |
 | ✅ **hCaptcha click / drag puzzles** | Full-puzzle model → pixel click/drag actions |
 | ✅ Cloudflare Turnstile | Works via the checkbox flow |
+| ✅ **GeeTest** (v3 + v4) | Slide, icon, nine, svg, gobang, iconcrush |
+| ✅ **NetEase Yidun** | Jigsaw, picture-click, icon-click |
+| ✅ **Lemin, Prosopo, Tencent** | Cropped-image, grid, and slide flows |
+| ✅ **Distorted text** | BotDetect, MTCaptcha, Yandex — read and typed, not clicked |
 | ✅ **Animated / video challenges** | Recorded (4 s @ 10 fps), cut into keyframes, solved as one multi-image prompt, then clicked once the widget returns to the chosen frame. The model half shipped with **v1.2**, which `setup.sh` installs and the hosted API serves |
+
+44 puzzle types across those 10 vendors. The per-type record — each puzzle
+driven on the vendor's own demo page, with the attempts scored — is in the
+[main README](../README.md#watch-it-work).
 
 Non-grid still-image puzzles — **click** ("click each …"), **drag** ("drag the
 piece into place"), path/connect, "choose the card" — route to the full-puzzle

--- a/docs/hosted-api.md
+++ b/docs/hosted-api.md
@@ -121,6 +121,14 @@ Refusals arrive as `CaptchaKrakenAPIError` with a machine-readable `code`.
 **Branch on the code, never on the message text** — wording changes, codes are
 the contract.
 
+```typescript
+import { CaptchaKrakenAPIError } from 'captchakraken';
+```
+
+```python
+from captchakraken import CaptchaKrakenAPIError
+```
+
 | `code` | Meaning | What to do |
 |---|---|---|
 | `insufficient_credits` | Balance is empty | Top up — MCP `get_topup_link`, or the dashboard |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,29 +5,38 @@ solve rates depend on more than the model.
 
 ## Accuracy
 
-> 🔬 **Being re-measured — no accuracy figures are published right now.**
->
-> The numbers that stood here were taken on **2026-07-27** against the deployed
-> `CaptchaKraken_v1.1` adapter. They excluded test images that appeared in a
-> labeled-train augment pool — but that exclusion was not the same thing as a
-> clean holdout, and the eval split of the day allowed some hand-labeled
-> captures into training. So the figures measured memorisation alongside skill,
-> by an amount that varied per puzzle type and was largest exactly where the
-> headline number was highest.
->
-> The split has since been replaced: **every** real capture is held out and
-> nothing hand-labeled trains, which is the only arrangement in which the real
-> captures can still detect generator drift. Figures return here after the next
-> full training run measures against it.
+**The figures we publish are the recorded solves in the
+[main README](../README.md#watch-it-work).** Thirteen puzzle types, each driven
+on the vendor's own public demo page through the hosted API, every attempt
+scored (one row excepted and labelled), recorded 2026-08-19 against the adapter
+the hosted API serves today. Counts rather than percentages, and a median
+whole-solve time taken from the run rather than from the footage.
 
-When they return, this is the method they will use, unchanged from before:
-exact set match — every correct tile selected and no incorrect ones, no partial
-credit, because a partially-correct grid answer is a rejected captcha — taken
-over the full customer path (HTTPS → gateway → vLLM) rather than against a
-local checkpoint, so it includes anything the serving stack does to a request.
+That is deliberately an **end-to-end** number — detect, read, click, verify, and
+the vendor accepting — not a model score. It is the one worth quoting because it
+is the one you experience.
 
-Latency is unaffected by any of the above and still holds: p10 0.84 s, median
-1.36 s, p90 1.76 s end to end including the network, median prompt 341 tokens.
+An earlier revision of this page carried per-type model accuracy taken on
+2026-07-27 against the then-deployed v1.1 adapter. Those figures were withdrawn:
+the eval split of the day let some hand-labeled captures reach training, so they
+measured memorisation alongside skill, by an amount that varied per puzzle type
+and was largest exactly where the headline number was highest. The split was
+replaced — **every** real capture is held out and nothing hand-labeled trains,
+which is the only arrangement in which real captures can still detect drift in
+the training data — and the model has been re-measured against it since. We are
+not restating a bare model-accuracy percentage here, because on its own it tells
+you very little about whether a captcha actually clears.
+
+The method behind the recorded solves: exact set match — every correct tile
+selected and no incorrect ones, no partial credit, because a partially-correct
+grid answer is a rejected captcha — taken over the full customer path
+(HTTPS → gateway → vLLM) rather than against a local checkpoint, so it includes
+anything the serving stack does to a request.
+
+Per-response latency, measured end to end including the network: **p10 0.84 s,
+median 1.36 s, p90 1.76 s**, median prompt 341 tokens. That is one model
+response; a captcha usually takes one or two, and the whole-solve medians in the
+README are the number that includes the vendor's own waiting.
 
 ### Grids must be sent with the cell numbers drawn on
 
@@ -35,15 +44,13 @@ This is the single biggest thing to get right in a client, and getting it wrong
 does not look like a bug — it looks like a bad model.
 
 `solver.py` runs `find_grid`, renders `get_numbered_grid_overlay` (red labels,
-top-right, all cells 1..N — byte-identical to the overlay
-`scripts/build_grid_overlays.py` used to build the training data) and sends
-*that* image. The model reads the labels. It does not infer a numbering from
-tile positions, because it was never trained to.
+top-right, all cells 1..N — byte-identical to the overlay the training data was
+built with) and sends *that* image. The model reads the labels. It does not
+infer a numbering from tile positions, because it was never trained to.
 
-Measured on the same 300 samples, overlay versus raw un-numbered screenshots.
-The absolute rates are from the superseded July measurement above and are not
-restated here; the ablation is a within-run comparison and the effect is far
-too large to be an artefact of the split:
+Measured over 300 samples, overlay versus raw un-numbered screenshots. This is a
+within-run ablation — the same images, the same model, the numbering the only
+difference — so it is reported as a relative effect:
 
 | Challenge | Raw screenshot, relative to the overlay |
 |---|---|
@@ -56,36 +63,23 @@ model invents a convention and answers `1..k` — right number of tiles, wrong
 region, mean IoU 0.33. A 3×3 of nine distinct photographs degrades far more
 gently, which is exactly why this mistake can hide.
 
-### The prompt is not the same on both sides
+### The model is trained on the prompt the client sends
 
-`canonical_instruction()` (training/grading) and `planner.SELECT_GRID_PROMPT`
-(the shipped client) are byte-identical for reCAPTCHA 4×4 and hCaptcha 3×3
-property, but **differ for reCAPTCHA 3×3**: the training prompt carries an
-extra paragraph the client omits —
+A model answers in whatever schema its prompt asks for, so a client that
+paraphrases the prompt does not get an error — it gets worse answers, on every
+puzzle, silently. The shipped grid and pixel prompts are therefore byte-identical
+to the ones the model was trained against, and a build check compares all five
+rather than trusting that they still match.
 
-> "Tiles with a blue checkmark badge are ALREADY CLEARED. Do not include them
-> in your answer. Tiles that are fading to white (mid-transition) are also
-> cleared and must be excluded."
+This is also why prompts are versioned **per model** rather than per client
+release: [`models.json`](../python/src/captchakraken/models.json) maps every
+published model to the prompt generation it was trained on, and the client ships
+the built-ins for each generation still in service. Pin a specific model with
+`CAPTCHA_LORA_ADAPTER` and you get that model's prompts; leave it unset and the
+weights and the prompts move forward together.
 
-Measured head-to-head on 240 paired reCAPTCHA 3×3 samples, the difference is
-not significant: 80.0% (client) vs 78.8% (training), 11 discordant pairs, exact
-two-sided sign test **p = 0.55**. That is expected on a static test set, where
-no tile is mid-transition. It may still matter in a live dynamic solve, where
-cleared tiles fade and are replaced — which is the case the paragraph exists
-for and the case this corpus cannot measure.
-
-### Two label bugs in the eval set
-
-Both are in `cleanSamples/test/test_solutions.json`, and both silently corrupt
-any harness that trusts the file naively:
-
-1. **Every one of the 288 real reCAPTCHA 4×4 images has a 3×3 instruction.**
-   The `instruction` field says `Grid: 3x3 (9 cells)` while the ground truth
-   names cells up to 16. `src/testing/grade.py` already sidesteps this —
-   `synthesize_instruction()` rebuilds the prompt from
-   `canonical_instruction(puzzle_type)` — so any new harness must do the same.
-2. **`rows`/`cols` disagree with `puzzle_type` on those same records.** Trust
-   `puzzle_type`; it is the only field that agrees with the answer.
+If you are writing your own client, send the prompts this one sends. Do not
+reword them.
 
 **Browser solve rates are a different measurement.** In a live run against
 `google.com/recaptcha/api2/demo` on 2026-07-27, Camoufox cleared 3/3 challenges,
@@ -137,9 +131,9 @@ model — 4070 and below, older Apple **Max** chips (fine on the 4-bit model), A
 **Pro**/base laptops, and older mid-range AMD.
 
 > ⏳ **Below ~30 tokens/sec, self-hosting feels sluggish.** If that is your card,
-> use the **hosted API** instead — it runs the production adapter on our fleet with no GPU of
-> yours involved, and the 240 requests measured above returned in a median
-> 1.6 s end to end including the network. Sign in at
+> use the **hosted API** instead — it runs the production adapter on our fleet
+> with no GPU of yours involved, at the per-response latency measured above
+> (median 1.36 s end to end, including the network). Sign in at
 > [captchakraken.com](https://captchakraken.com/signin). `setup.sh` estimates
 > your speed from your device's bandwidth (NVIDIA / AMD / Apple) and flags this
 > automatically.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,29 +10,23 @@ Where CaptchaKraken is headed. Legend: 🟢 shipped · 🟡 in progress · ⚪ p
 | ⬇️ **Unified `fetch` command** | 🟢 shipped | `captchakraken fetch` pulls the latest weights from HF **and** upgrades vLLM in one step. See [Self-hosting → Updating](./self-hosting.md#updating). |
 | ♻️ **Per-solve solution dedup** | 🟢 shipped | Byte-identical frames are never re-sent to vLLM. |
 | ☁️ **Hosted cloud API** | 🟢 shipped | `api.captchakraken.com`. Self-serve signup with GitHub, free credits on the account, metered per inference round. Answers with **Twilight v1.2**. |
-| 🧩 **hCaptcha click / drag puzzles** | 🟢 shipped | Full-puzzle model → pixel-space click/drag actions. |
-
-## 🏷️ Known data issues
-
-| Item | Status | Notes |
-|---|---|---|
-| **4×4 eval labels** | 🔴 known bad | All 288 real 4×4 records in `test_solutions.json` carry a 3×3 instruction, and their `rows`/`cols` disagree with `puzzle_type`. `grade.py` works around it via `canonical_instruction()`; the file itself still needs fixing. |
-| **Train/infer prompt parity** | 🟡 in progress | `canonical_instruction()` and the shipped `SELECT_GRID_PROMPT` differ for reCAPTCHA 3×3 (the already-cleared-tiles paragraph). Measured p = 0.55 on a static corpus, but it is the live-dynamic case the paragraph exists for. |
+| 🧩 **hCaptcha click / drag puzzles** | 🟢 shipped | Full-puzzle model → pixel-space click/drag actions. Click, drag, path/connect and tetris-fit all route and are driven. |
+| 🪶 **Sunlight / Twilight merges** | 🟢 shipped | The adapter merged into the base at 4-bit (11 GB) and 8-bit (13 GB), so self-hosting is one download instead of two. Published for both v1.1 and v1.2, all public on [HuggingFace](https://huggingface.co/CaptchaKraken). |
+| 🎥 **Video challenge support** | 🟢 shipped | **Both halves are out.** A challenge that never settles is recorded (4 s @ 10 fps), cut into keyframes, and sent to the model as one multi-image prompt; the answer names which keyframe it acted on, and the driver waits for the widget to return to that frame before clicking. The model half shipped with **v1.2** — trained on the keyframe format, installed by `setup.sh`, and what the hosted API answers with. |
+| 📱 **Mobile / touch input** | 🟢 shipped | `humanization: 'mobile'` dispatches real touch events with finger kinematics, in a Chromium page with `hasTouch` or at a real handset over Appium / WebdriverIO / Selenium. See [Usage → How it moves](./usage.md#how-it-moves--mouse-mobile-none-or-yours). |
 
 ## 🟡 In progress
 
 | Item | Status | Notes |
 |---|---|---|
-| ⬛ **Abyss** | 🟡 in progress | The next hosted-only model, trained against the open weights' measured failures. **Not serving yet** — the endpoint answers with Twilight v1.2 until it lands. |
-| 🪶 **Sunlight / Twilight merges** | 🟢 shipped | The adapter merged into the base at 4-bit (~9 GB) and 8-bit (~14 GB), so self-hosting is one download instead of two. Published for both v1.1 and v1.2, all public on [HuggingFace](https://huggingface.co/CaptchaKraken). |
+| ⬛ **Abyss** | 🟡 in progress | The next hosted-only model, on a larger base, trained against the open weights' measured failures. **Not serving yet** — the endpoint answers with Twilight v1.2 until it lands. |
 | 📈 **More real labeled data** | 🟡 in progress | Broader coverage for under-represented prompts. |
-| 🎥 **Video challenge support** | 🟢 shipped | **Both halves are out.** A challenge that never settles is recorded (4 s @ 10 fps), cut into keyframes, and sent to the model as one multi-image prompt; the answer names which keyframe it acted on, and the driver waits for the widget to return to that frame before clicking. The model half shipped with **v1.2** — trained on the keyframe format, installed by `setup.sh`, and what the hosted API answers with. |
 
 ## ⚪ Planned
 
 | Item | Status | Notes |
 |---|---|---|
-| 🧩 **More captcha types** | ⚪ planned | The non-grid hCaptcha puzzles still unhandled: tetris-fit and "choose the card". Click, drag and path/connect have shipped (above). |
+| 🎯 **Freehand hCaptcha accuracy** | ⚪ planned | Connect-the-path and the numbered-line / missing-piece drags are the families the model is least reliable on. They are routed and driven today; this is about how often they land. |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,9 +64,37 @@ could not RECORD — note this no longer means "the challenge moves"; a moving
 challenge is recorded and solved from keyframes), and `CaptchaSolveError` for
 everything else.
 
-Tune with `PageSolverConfig`; its fields are the snake_cased names of the
-TypeScript `CaptchaKrakenConfig` keys, so a value tuned on one driver is findable
-on the other.
+Tune with `PageSolverConfig`. Its fields are the snake_cased names of the
+TypeScript `CaptchaKrakenConfig` keys, so a value tuned on one driver is
+findable on the other — with the exceptions below, which are worth knowing
+because guessing wrong is silent on the Python side.
+
+**Three keys are not a plain snake_case of the TypeScript name.** The TS names
+capitalise the `S` in "re-solve":
+
+| Python | TypeScript |
+|---|---|
+| `stale_frame_resolve_enabled` | `staleFrameReSolveEnabled` |
+| `max_stale_frame_resolves` | `maxStaleFrameReSolves` |
+| `max_unsupported_resolves` | `maxUnsupportedReSolves` |
+
+**Two have different shapes.** `starting_mouse_position` is a `(x, y)` tuple in
+Python and a `{ x, y }` object in TypeScript; `touch_transform`'s `origin` is a
+tuple in Python and an array in TypeScript.
+
+**A few exist on one side only**, because they configure something only that
+side has:
+
+| Only in Python | Only in TypeScript |
+|---|---|
+| `animated_probe_enabled` | `onStep` — a per-step callback for progress UI |
+| `slide_probe_offsets_px` | `idleMouseWander` |
+| `slide_tolerance_px` | `repoPath`, `pythonCommand` — where the bundled engine lives |
+| `slide_max_corrections` | `model`, `apiKey` — Python takes these on `PageSolver(...)` itself |
+
+Everything that decides **accuracy** — the prompts, the CV, the pixel budget,
+the model — lives in the shared Python half and is identical by construction.
+The differences above are all in the driving layer.
 
 > **The Python driver is synchronous only.** A sync Playwright handle cannot be
 > driven from inside an event loop, so `async_playwright` and `AsyncCamoufox`

--- a/js/README.md
+++ b/js/README.md
@@ -103,15 +103,78 @@ await browser.close();
 
 Puppeteer users wrap the page once with `fromPuppeteer(page)`.
 
+## How it moves — mouse, mobile, none, or yours
+
+Solving a captcha is two jobs: reading the puzzle, and *performing* the answer.
+The second is a choice of **input device**, not a realism dial.
+
+```typescript
+new CaptchaKrakenSolver({ humanization: 'mouse' })   // default
+new CaptchaKrakenSolver({ humanization: 'mobile' })  // real touch events
+new CaptchaKrakenSolver({ humanization: 'none' })    // straight to the DOM effect
+new CaptchaKrakenSolver({ humanizer: myOwn })        // yours; overrides the above
+```
+
+Unset, it reads `CAPTCHA_HUMANIZATION` and then falls back to `mouse` — which is
+byte-for-byte what the driver did before the option existed, so nothing moves for
+an existing caller. Anything set in code **wins** over the env var: which mode is
+right is a property of the page you are driving, not a deployment decision.
+
+`mobile` never touches `page.mouse`. A mousemove at a touch-only widget is the
+*wrong event*, not a weaker one — the page's touch handlers never fire and the
+solve fails for a reason nothing reports. It needs a Chromium-family page with
+touch turned on:
+
+```typescript
+import { chromium, devices } from 'playwright';
+
+const context = await browser.newContext({ ...devices['Pixel 7'], hasTouch: true });
+await new CaptchaKrakenSolver({ humanization: 'mobile' }).solve(await context.newPage());
+```
+
+Or drive a real handset over **Appium / WebdriverIO / Selenium** — gestures go
+out as W3C pointer actions with `pointerType: "touch"`:
+
+```typescript
+new CaptchaKrakenSolver({
+  humanization: 'mobile',
+  touchDriver: driver,                            // your Appium / WebdriverIO session
+  touchTransform: { scale: 3, origin: [0, 132] }, // CSS px -> screen px
+});
+```
+
+`touchTransform` is required rather than guessed: get it wrong and nothing
+raises — the action chain is valid, the device performs it, and the finger lands
+somewhere else. A `touchDriver` with no `scale` on a page reporting
+`devicePixelRatio !== 1` refuses on the first gesture and names the value to pass.
+
+Full details, including writing your own humanizer:
+[docs/usage.md § How it moves](https://github.com/JWriter20/CaptchaKraken/blob/main/docs/usage.md#how-it-moves--mouse-mobile-none-or-yours).
+
 ## Configuration
 
-| Variable | Meaning |
-|---|---|
-| `VLLM_BASE_URL` | Inference endpoint (local vLLM, a server you run, or `https://api.captchakraken.com/v1`) |
-| `CAPTCHA_KRAKEN_API_KEY` | Bearer token (`VLLM_API_KEY` also accepted) |
+| Variable | Meaning | Default |
+|---|---|---|
+| `VLLM_BASE_URL` | Inference endpoint (local vLLM, a server you run, or `https://api.captchakraken.com/v1`) | credentials file, else `http://localhost:8000/v1` |
+| `CAPTCHA_KRAKEN_API_KEY` | Bearer token (`VLLM_API_KEY` also accepted) | credentials file, else `EMPTY` |
+| `CAPTCHA_HUMANIZATION` | How gestures are performed: `mouse`, `mobile` or `none`. Loses to anything set in code | `mouse` |
+| `CAPTCHA_BASE_MODEL` | Base weights vLLM loads | `RedHatAI/Qwen3.5-9B-FP8-dynamic` |
+| `CAPTCHA_LORA_ADAPTER` | Captcha adapter (HF id or path) | `CaptchaKraken/CaptchaKraken-Lora-v1.2` |
+| `CAPTCHA_LORA_NAME` | Served adapter name sent as `model` | `captcha-v12` |
+| `CAPTCHA_KRAKEN_AUTOSTART` | `0` never auto-starts a local server | `1` |
+| `CAPTCHA_KRAKEN_PYTHON` | Interpreter used for the bundled engine | the package's venv, else `python3` |
+| `CAPTCHA_KRAKEN_SKIP_PYTHON_SETUP` | `1` skips the `postinstall` bootstrap | unset |
+| `CAPTCHA_DEBUG` | `1` prints solver diagnostics to stderr | `0` |
 
-Both fall back to `~/.captchakraken/credentials` when unset, so the hosted API
-needs no environment variables at all.
+`VLLM_BASE_URL` and `CAPTCHA_KRAKEN_API_KEY` fall back to
+`~/.captchakraken/credentials` when unset, so the hosted API needs no
+environment variables at all.
+
+**Why the model and server variables appear here.** This package bundles the
+Python engine and spawns it, forwarding the environment wholesale — so every
+variable the engine reads applies to a TypeScript solve too. The full list, and
+the vLLM server knobs, are in
+[AGENTS.md § Environment variables](https://github.com/JWriter20/CaptchaKraken/blob/main/AGENTS.md#environment-variables).
 
 ## License
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -176,7 +176,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export function createServer(baseUrl: string, clientName: string): McpServer {
   const api = new ControlPlane(baseUrl);
   const server = new McpServer(
-    { name: 'captchakraken', version: '0.1.0' },
+    { name: 'captchakraken', version: '0.1.2' },
     {
       instructions:
         'CaptchaKraken account management. Use sign_in once to connect a GitHub account, ' +

--- a/python/src/captchakraken/__init__.py
+++ b/python/src/captchakraken/__init__.py
@@ -32,6 +32,12 @@ from .action_types import (
 from .image_processor import ImageProcessor
 from .overlay import add_overlays_to_image
 
+# The hosted API's refusal type. Outside the try below on purpose: `errors`
+# imports nothing but `typing`, and docs/hosted-api.md tells every caller to
+# branch on its `.code` — a recipe that has to work in both ports, and in a
+# minimal install that has no serving stack.
+from .errors import CaptchaKrakenAPIError
+
 # How gestures are PERFORMED — mouse, touch, or nothing. Deliberately outside
 # the try below: `humanize` imports only `trajectory`, so it has no dependency
 # floor at all, and a caller writing a custom Humanizer must be able to import
@@ -85,6 +91,7 @@ __all__ = [
     "TypeAction",
     "WaitAction",
     "add_overlays_to_image",
+    "CaptchaKrakenAPIError",
     "Humanizer",
     "MouseHumanizer",
     "MobileHumanizer",
@@ -95,4 +102,4 @@ __all__ = [
     "TouchscreenTouchBackend",
 ]
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/python/src/captchakraken/models.json
+++ b/python/src/captchakraken/models.json
@@ -6,10 +6,9 @@
     "Why a map and not a constant: a model answers in whatever schema its prompt",
     "asks for. Send a version-1 model the version-2 prompt and nothing errors —",
     "it just answers worse, on every puzzle, silently. That is exactly the",
-    "2026-07-18 regression (failure-mode 3 in the finetune repo's",
-    "scripts/check_prompt_parity.py), where the shipped prompt kept asking for",
-    "the legacy output/simulate_drag/PascalCase schema long after the LoRA had",
-    "been retrained on action: drag / drags[].",
+    "2026-07-18 regression, where the shipped prompt kept asking for the legacy",
+    "output/simulate_drag/PascalCase schema long after the LoRA had been",
+    "retrained on action: drag / drags[].",
     "",
     "Hardcoding one generation makes that inevitable the moment a new model",
     "trains on different prompts: updating the constants breaks every already-",
@@ -27,10 +26,9 @@
     "never see `latest`, so they are not silently moved onto prompts they cannot",
     "produce.",
     "",
-    "Adding a model: add its entry here IN THE SAME COMMIT as publishing it. The",
-    "finetune repo's check_prompt_parity.py fails if any registered model names a",
-    "prompt_version this client ships no built-ins for, so an unmapped model",
-    "cannot reach a release.",
+    "Adding a model: add its entry here IN THE SAME COMMIT as publishing it. A",
+    "release gate fails if any registered model names a prompt_version this",
+    "client ships no built-ins for, so an unmapped model cannot reach a release.",
     "",
     "`pixel_budget` is the same idea for RESOLUTION. Qwen reads MIN_PIXELS /",
     "MAX_PIXELS from the environment and clamps each image's AREA into that band,",
@@ -61,7 +59,7 @@
         "min": 518400,
         "max": 518400
       },
-      "note": "Run 20260812-005302 (ready-to-deploy). PUBLIC on the Hub under Source-Available License v1.1, and the first published generation-2 model. TRAINED with floor 448^2 / ceiling 720^2, but MEASURED best served at a flat 720^2 — floor == ceiling, so every image arrives at exactly one size. Tier 2 overall 0.6115 -> 0.6412 across the full 1458-sample real eval and reCAPTCHA 3x3 exact 0.648 -> 0.715, against run-to-run noise of +/-0.001. Swept 2026-08-18 over 448/576/640/704/720/736/768/896/1024^2: the plateau is 704-736^2 and it falls off above 768^2, where a 400x580 portrait capture runs more than 40% past the ViT's 48x48 position grid. Note 640^2 is where that grid is exactly saturated and it scores WORSE (0.6357) — mild extrapolation plus real pixels beats staying inside the grid. Was served as `captcha-v12` while absent from this file, which resolved it to generation 1 prompts against generation-2 weights — the failure this file exists to prevent."
+      "note": "PUBLIC on the Hub under Source-Available License v1.1, and the first published generation-2 model. TRAINED with floor 448^2 / ceiling 720^2, but MEASURED best served at a flat 720^2 — floor == ceiling, so every image arrives at exactly one size and the band cannot drift. The band was chosen by sweeping the serving floor over 448/576/640/704/720/736/768/896/1024^2 and scoring each arm: the plateau is 704-736^2, and it falls off above 768^2, where a 400x580 portrait capture runs more than 40% past the ViT's 48x48 position grid. Do not \"just use the ViT's native grid\": 640^2 is where that grid is exactly saturated for a portrait capture, and it scores WORSE than 720^2 — mild position-embedding extrapolation plus real pixels beats staying inside the grid. Was served as `captcha-v12` while absent from this file, which resolved it to generation 1 prompts against generation-2 weights — the failure this file exists to prevent."
     },
     "CaptchaKraken/Twilight-v1.2-FP8": {
       "prompt_version": "2",

--- a/python/src/captchakraken/pinned_model.json
+++ b/python/src/captchakraken/pinned_model.json
@@ -12,8 +12,9 @@
     "serving prompt fails CI until someone consciously re-pins \u2014 which forces",
     "the question 'does the pinned adapter still expect this prompt?'.",
     "",
-    "To ship a new adapter: update lora_adapter/lora_revision, re-run the Tier 2",
-    "static-image gate against it, and update prompt_sha256 if the prompts moved."
+    "To ship a new adapter: update lora_adapter/lora_revision, re-run the",
+    "static-image accuracy gate against it, and update prompt_sha256 if the",
+    "prompts moved."
   ],
   "base_model": "RedHatAI/Qwen3.5-9B-FP8-dynamic",
   "lora_adapter": "CaptchaKraken/CaptchaKraken-Lora-v1.2",

--- a/python/tests/test_api_error_is_exported.py
+++ b/python/tests/test_api_error_is_exported.py
@@ -1,0 +1,23 @@
+"""`CaptchaKrakenAPIError` must be importable from the package root.
+
+Rule 1c: the two ports expose the same surface. The TypeScript port exports
+`CaptchaKrakenAPIError` from its entry point, and docs/hosted-api.md tells
+every caller to branch on its `.code` — but in Python it lived only in
+`captchakraken.errors`, so the documented recipe did not work in one of the
+two languages the docs claim parity for.
+
+`errors` imports nothing but `typing`, so this export carries no dependency
+floor and belongs outside the optional serving-stack guard.
+"""
+
+import captchakraken
+
+
+def test_api_error_importable_from_package_root():
+    from captchakraken import CaptchaKrakenAPIError
+
+    assert issubclass(CaptchaKrakenAPIError, Exception)
+
+
+def test_api_error_is_in_dunder_all():
+    assert "CaptchaKrakenAPIError" in captchakraken.__all__

--- a/python/tests/test_version_matches_manifest.py
+++ b/python/tests/test_version_matches_manifest.py
@@ -1,0 +1,30 @@
+"""`captchakraken.__version__` must equal the version pip installs.
+
+It drifted once already: 2.6.1 shipped on PyPI and on npm while
+`__init__.py` still said 2.6.0, so every caller that branches on
+`captchakraken.__version__` — and every bug report that quotes it —
+named a release that was not the one running.
+
+Nothing else checks it. `pyproject.toml` is the manifest pip reads, so it
+is the one this compares against; a mismatch is a release-hygiene bug, not
+a matter of opinion.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import captchakraken
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def test_dunder_version_matches_pyproject():
+    if not _PYPROJECT.exists():  # installed without the sdist's manifest
+        pytest.skip("pyproject.toml is not next to the tests in this install")
+    declared = re.search(
+        r'^version\s*=\s*"([^"]+)"', _PYPROJECT.read_text(encoding="utf-8"), re.M
+    )
+    assert declared, "no version field in pyproject.toml"
+    assert captchakraken.__version__ == declared.group(1)


### PR DESCRIPTION
An audit of every customer-facing doc in this repo against the code as it actually is today. Most of what was wrong was **stale, not invented** — true when written, never revisited.

## What a reviewer should check, in priority order

### 1. A published number we could not stand behind
`README.md` listed the hCaptcha **drag puzzle** as `9/10 solved · 9.0s median`, under a preamble promising "every attempt scored". That row is `supplied: true` upstream — hCaptcha deals the puzzle too rarely for us to have a scored run, and the figures were **asserted by hand**. The clip stays; the count and median are gone and the row is labelled. The preamble now says twelve of the thirteen were scored.

**Check:** that you agree a hand-written figure that looks exactly like a measured one is worse than no figure, days before a licensing conversation.

### 2. Private measurement internals removed from a public repo
`python/src/captchakraken/models.json` shipped — to PyPI, in the package — an aggregate solve rate, the eval corpus size, a per-type score, and the path of a script in a private repo. `docs/performance.md` went further: the path of the hand-labelled answers file, the names of private grading functions, and a whole section documenting **two label bugs in our eval set**.

None of it helps a customer and all of it describes a private eval set. **The engineering rationale in `models.json` is kept in full** — why a prompt generation is per-model, why `pixel_budget` is serve-at rather than trained-at, why 640² scores worse than 720² — because a self-hoster needs it. Only the measurements left.

**Check:** `git diff` on `models.json` — confirm nothing operational was lost. Nothing reads the `note` field; it is documentation.

### 3. Claims that were simply out of date
- **Accuracy was blank.** README and `performance.md` both said figures were withdrawn and would return "after the next full training run". That run happened. Rather than restate a bare model-accuracy percentage — which on its own says little about whether a captcha clears — both now point at the recorded end-to-end solves.
- **tetris-fit shipped.** It routes, is driven, and scores above the aggregate. `roadmap.md` called it "still unhandled" and `CONTRIBUTING.md` called it out of scope.
- **"Choose the card"** was listed as a planned puzzle type. It is not a type we track at all.
- **Train/infer prompt parity for reCAPTCHA 3×3 was closed on 2026-08-03** — the shared text is byte-identical to the client's generation-2 built-in now. Two documents still described it as an open problem.
- **Mobile/touch input shipped** and appeared on no roadmap.
- `roadmap.md` quoted the **v1.1 merge sizes** (~9/~14 GB) while claiming to describe both generations; v1.2 is 11/13 GB.
- `docs/README.md`'s "what it solves" table was missing **six vendors** the main README lists.

### 4. Rule 1c — the two ports now document the same surface
The commit that added `humanization` documented it in `python/README.md`, `README.md`, `AGENTS.md`, `docs/usage.md` and the changelog. **`js/README.md` got nothing**, and its configuration table listed two variables out of ten. The npm package bundles the Python engine and forwards the environment wholesale, so every one of those variables applies to a TypeScript solve too.

`docs/usage.md` also claimed `PageSolverConfig` fields are "the snake_cased names of the TypeScript keys". Three are not — `staleFrameReSolveEnabled`, `maxStaleFrameReSolves`, `maxUnsupportedReSolves` capitalise the S. Two have different shapes. Eight exist on one side only. **Guessing wrong is silent on the Python side**, so the exceptions are now a table.

### 5. CONTRIBUTING told contributors to do two impossible things
- "Branch off `main`" — `main` only ever takes a `dev` merge.
- Verify new solving capability by running a recorder **in a repo they cannot access**.

It also described CI as a type-check plus a grid test, omitting the driver gate that actually runs on their PR — including why it shows as pending on a fork.

## Two code fixes, each with a regression test written first and confirmed failing

- **`captchakraken.__version__` said `2.6.0`** while `2.6.1` was published to both registries. Nothing compared it to the manifest pip reads. `python/tests/test_version_matches_manifest.py`.
- **`CaptchaKrakenAPIError` was exported from the TypeScript entry point but not the Python one**, while `docs/hosted-api.md` tells every caller to branch on its `.code`. **Purely additive** — the old `captchakraken.errors` import still works, and `errors` imports nothing but `typing`, so it adds no dependency floor. `python/tests/test_api_error_is_exported.py`.

## Backwards compatibility

**Nothing here breaks an existing integration.** No public name was removed or renamed, no default changed, no env var retired. The two code changes are a corrected constant and an added export.

## Verification

- `python -m pytest -q` → **452 passed, 15 skipped** (449 before; +3 new)
- `npm test` → **123/123**
- `tsc --noEmit -p tsconfig.json` → clean

## Note on CI

`ci.yml` and `tier3-request.yml` both trigger only on `pull_request: branches: [main]`, so **this PR into `dev` runs no checks**. That is pre-existing and I deliberately did not change it — `tier3-request.yml` dispatches the contended private runner, and another agent is working on serialising that. Worth deciding separately whether the hermetic `ci.yml` should also run on `dev` PRs; it is free and runs on `ubuntu-latest`. The results above are from running both suites locally on this branch.