### PR TITLE
Pin the published surface, and gate PRs into dev at all

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -4,7 +4,19 @@
  *   node .github/scripts/mcp-smoke.mjs node dist/index.js
  *
  * Does the real handshake over stdio — initialize, notifications/initialized,
- * tools/list — and exits non-zero unless at least one tool comes back.
+ * tools/list — and then checks the tools that come back against
+ * ../../contract.json.
+ *
+ * IT USED TO CHECK `names.length > 0`. Eleven tools could become one and this
+ * exited 0, having printed the missing ten's absence as a shorter list nobody
+ * reads. `revoke_api_key` could lose its `id` parameter, `get_usage` its 1..30
+ * bound, or every tool its name, and the gate said the server speaks MCP —
+ * which was true and not what anyone wanted to know. The tool names and their
+ * input schemas ARE the published surface of this package: an agent calls them
+ * by name and fills them by field.
+ *
+ * Regenerate after an intended change with CONTRACT_WRITE=1 and commit the
+ * ../../contract.json diff.
  *
  * WHY THIS EXISTS RATHER THAN JUST `tsc`: the failure mode worth catching is a
  * server that compiles perfectly and then cannot complete a handshake, because
@@ -17,6 +29,12 @@
  * network, and nothing to clean up.
  */
 import { spawn } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import assert from 'node:assert/strict';
+
+const CONTRACT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'contract.json');
 
 const cmd = process.argv[2];
 const args = process.argv.slice(3);
@@ -64,7 +82,40 @@ try {
   const names = (tools.result?.tools ?? []).map((t) => t.name);
   console.log(`tools/list OK — ${names.length} tools:`);
   for (const n of names) console.log('  -', n);
-  process.exitCode = names.length > 0 ? 0 : 1;
+
+  // The published shape of each tool: its name, which fields it takes, and
+  // which of them are REQUIRED. Descriptions are prose and deliberately not
+  // pinned — rewording a help string is not a breaking change.
+  const live = Object.fromEntries(
+    (tools.result?.tools ?? [])
+      .map((t) => [
+        t.name,
+        {
+          properties: Object.keys(t.inputSchema?.properties ?? {}).sort(),
+          required: (t.inputSchema?.required ?? []).slice().sort(),
+        },
+      ])
+      .sort((a, b) => a[0].localeCompare(b[0])),
+  );
+
+  const contract = JSON.parse(readFileSync(CONTRACT, 'utf8'));
+  if (process.env.CONTRACT_WRITE === '1') {
+    contract.mcp = { server_name: init.result?.serverInfo?.name, tools: live };
+    writeFileSync(CONTRACT, JSON.stringify(contract, null, 2) + '\n');
+    console.log(`wrote ${CONTRACT}`);
+  }
+
+  assert.deepEqual(
+    live,
+    contract.mcp.tools,
+    'the MCP tool surface changed. An agent calls these by name and fills them ' +
+      'by field, so a rename or a dropped parameter breaks every configured ' +
+      'client silently. If intended, re-run with CONTRACT_WRITE=1 in the same ' +
+      'commit and bump mcp/package.json.',
+  );
+  assert.equal(init.result?.serverInfo?.name, contract.mcp.server_name);
+  console.log(`contract OK — ${Object.keys(live).length} tools match contract.json`);
+  process.exitCode = 0;
 } catch (e) {
   console.error('FAILED:', e.message);
   console.error('stderr was:\n' + stderrChunks.join(''));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,16 @@ name: CI
 # Fast, hermetic checks for both ports: no GPU, no network, no model weights.
 # The core guard is grid detection (the foundation of every solve) plus a
 # TypeScript build check on the browser solver.
+#
+# `dev` IS LISTED, and it was not. A pull request into `dev` ran nothing here at
+# all — checked 2026-08-28 on #16, whose only check was GitGuardian — so work
+# landed on the integration branch ungated and first met CI at the `dev -> main`
+# promotion, where a failure blocks the RELEASE instead of the change that
+# caused it. These jobs are hermetic and run on ubuntu-latest, which is free for
+# a public repo, so there was never a cost argument for the narrower trigger.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   # Reused by publish.yml as the pre-publish gate on main pushes.
   workflow_call:
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,87 @@
+name: promote
+
+# `main` accepts merges from `dev`, and from nothing else.
+#
+# WHY THIS IS A WORKFLOW AND NOT A SETTING. Branch protection can require a pull
+# request, require checks, and say who may push — but it has no rule for which
+# branch may be the SOURCE of a merge. So the one property that actually
+# describes this project's release flow is the one GitHub cannot express, and a
+# required check is the only place to put it. captchakraken-cloud and
+# captchakraken-gateway have carried this file since 2026-08-22; this repo and
+# the public one did not, which meant three of the four repos on the release
+# path enforced the route and the two that ship the MODEL and the DRIVER did
+# not.
+#
+# WHAT IT BUYS HERE, specifically. `publish.yml` fires on push to `main`, so
+# anything that lands there is on npm and PyPI a few minutes later, under a
+# version number that can never be reused. There is no rollback for a publish —
+# only a higher version — which makes this the most irreversible `main` of the
+# four repos on the release path, and it was the least protected.
+#
+# The route through `dev` is not ceremony. A driver change is proved by the
+# PRIVATE repo's Tier 3 gate, dispatched from here by tier3-request.yml and
+# reported back as `tier3/driver-gate`. That gate drives the fixtures with the
+# commit's own code on both ports; sitting on `dev` first is what gives it a
+# chance to run against everything else in flight rather than only against
+# `main`.
+#
+# BREAKING GLASS. There is no bypass in here on purpose — a check with an escape
+# hatch in its own logic is a check that will be escaped. If `main` genuinely has
+# to take a commit that is not on `dev`, the honest move is to turn this check
+# off in Settings → Branches for the length of the incident and turn it back on,
+# which is deliberate, visible in the audit log, and takes two clicks. Pushing
+# the fix to `dev` and promoting it is usually faster than either.
+
+on:
+  pull_request:
+    branches: [main]
+
+# Nothing here reads code or secrets; it inspects the event.
+permissions:
+  contents: read
+
+jobs:
+  source-branch:
+    name: source branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: main accepts merges from dev only
+        env:
+          # Through the environment, never interpolated into the script body:
+          # a branch name is attacker-controlled on a fork PR, and `${{ }}`
+          # inside `run:` is a shell injection.
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::This pull request comes from $HEAD_REPO, not $BASE_REPO."
+            echo "main is promoted from this repository's own 'dev' branch."
+            exit 1
+          fi
+
+          if [ "$HEAD_REF" != "dev" ]; then
+            echo "::error::main accepts merges from 'dev' only; this one is from '$HEAD_REF'."
+            cat <<'EOF'
+
+          The release path is:
+
+              your branch  ──PR──>  dev  ──PR──>  main
+                                                     │
+                                                     └─ publishes captchakraken
+                                                        to npm and PyPI, and
+                                                        captchakraken-mcp to npm
+
+          Retarget this pull request at 'dev'. Once it is merged there, open a
+          second pull request from 'dev' to 'main' — that one runs the hermetic
+          gates plus tier3/driver-gate before anything is published.
+
+          EOF
+            exit 1
+          fi
+
+          echo "Source branch is 'dev'. This is a promotion."

--- a/contract.json
+++ b/contract.json
@@ -1,0 +1,512 @@
+{
+  "python": {
+    "version": "2.6.1",
+    "exports": [
+      "ActionPlanner",
+      "AppiumTouchBackend",
+      "CaptchaAction",
+      "CaptchaSolver",
+      "CaptchaWatcher",
+      "CdpTouchBackend",
+      "ClickAction",
+      "DragAction",
+      "Humanizer",
+      "ImageProcessor",
+      "MobileHumanizer",
+      "MouseHumanizer",
+      "NullHumanizer",
+      "PageSolver",
+      "SolveResult",
+      "TouchBackend",
+      "TouchscreenTouchBackend",
+      "TypeAction",
+      "WaitAction",
+      "add_overlays_to_image",
+      "solve_captcha",
+      "solve_captcha_on_page"
+    ],
+    "signatures": {
+      "solve_captcha": "(media_path: str, instruction: str = '', *, puzzle_source: str = 'unknown', retry_mode: str | None = None, text_mode: bool = False, **kwargs: Any) -> Any",
+      "CaptchaSolver.__init__": "(self, model: str | None = None, provider: str = 'captchaKrakenApi', api_key: str | None = None)",
+      "CaptchaSolver.solve": "(self, media_path: str, instruction: str = '', puzzle_source: str = 'unknown', retry_mode: str | None = None, text_mode: bool = False) -> captchakraken.action_types.ClickAction | captchakraken.action_types.DragAction | captchakraken.action_types.TypeAction | captchakraken.action_types.WaitAction | captchakraken.action_types.DoneAction | List[captchakraken.action_types.ClickAction | captchakraken.action_types.DragAction | captchakraken.action_types.TypeAction | captchakraken.action_types.WaitAction | captchakraken.action_types.DoneAction]",
+      "CaptchaSolver.solve_keyframes": "(self, keyframe_paths: Sequence[str]) -> List[captchakraken.action_types.ClickAction | captchakraken.action_types.DragAction]",
+      "PageSolver.__init__": "(self, config: 'Optional[PageSolverConfig]' = None, solver: 'Optional[CaptchaSolver]' = None, **solver_kwargs: 'Any') -> 'None'",
+      "PageSolver.solve": "(self, page: 'Any') -> 'SolveResult'",
+      "PageSolver.watch": "(self, page: 'Any', **options: 'Any') -> \"'CaptchaWatcher'\"",
+      "solve_captcha_on_page": "(page: 'Any', **kwargs: 'Any') -> 'SolveResult'",
+      "CaptchaKrakenAPIError.__init__": "(self, message: str, *, status: int | None = None, code: str | None = None, resolution_url: str | None = None, retry_after_seconds: float | None = None)",
+      "add_overlays_to_image": "(image_path: str, boxes: list[dict], output_path: str = None, label_position='top-left')",
+      "humanize.resolve": "(config: 'Any') -> 'Humanizer'"
+    },
+    "page_solver_config_fields": [
+      "animated_challenge_after_ms",
+      "animated_probe_enabled",
+      "element_screenshot_timeout_ms",
+      "grid_load_poll_interval_ms",
+      "grid_load_timeout_ms",
+      "hcaptcha_images_timeout_ms",
+      "humanization",
+      "humanizer",
+      "keyframe_wait_poll_ms",
+      "keyframe_wait_timeout_ms",
+      "max_no_progress_rounds",
+      "max_solve_loops",
+      "max_stale_element_retries",
+      "max_stale_frame_resolves",
+      "max_unsupported_resolves",
+      "overall_solve_timeout_ms",
+      "post_solve_delay_ms",
+      "post_solve_outcome_poll_ms",
+      "post_solve_outcome_timeout_ms",
+      "post_submit_change_timeout_ms",
+      "recaptcha_dynamic_fade_poll_ms",
+      "recaptcha_dynamic_fade_wait_ms",
+      "recaptcha_fade_onset_grace_ms",
+      "recaptcha_max_dynamic_rounds",
+      "recaptcha_tile_hover_enabled",
+      "settle_diff_threshold",
+      "settle_frames",
+      "settle_poll_ms",
+      "settle_timeout_ms",
+      "slide_max_corrections",
+      "slide_probe_offsets_px",
+      "slide_tolerance_px",
+      "stale_element_backoff_ms",
+      "stale_frame_diff_threshold",
+      "stale_frame_resolve_enabled",
+      "starting_mouse_position",
+      "touch_driver",
+      "touch_transform",
+      "video_burst_duration_ms",
+      "video_burst_fps",
+      "video_extra_inference_ms",
+      "video_solve_enabled"
+    ],
+    "solve_result_fields": [
+      "final_mouse_position",
+      "is_solved",
+      "token_usage"
+    ],
+    "config_functions": [
+      "api_key",
+      "autostart_enabled",
+      "base_model",
+      "base_url",
+      "credentials_path",
+      "extra_serve_args",
+      "gpu_memory_utilization",
+      "lora_adapter",
+      "lora_name",
+      "lora_revision",
+      "max_lora_rank",
+      "max_model_len",
+      "pinned",
+      "port",
+      "state_dir"
+    ],
+    "error_codes": [
+      "account_suspended",
+      "insufficient_credits",
+      "invalid_api_key",
+      "missing_api_key",
+      "rate_limited",
+      "request_too_large",
+      "solve_abandoned",
+      "upstream_unavailable"
+    ],
+    "humanization_modes": [
+      "mobile",
+      "mouse",
+      "none"
+    ]
+  },
+  "cli": {
+    "entry_point": "captchakraken = captchakraken.cli:main",
+    "subcommands": [
+      "check-movement",
+      "check-movement-batch",
+      "detect-selected",
+      "fetch",
+      "find-checkbox",
+      "find-grid",
+      "find-movable",
+      "find-move",
+      "get-numbered-grid",
+      "grid-cell-states",
+      "grid-cell-states-fixed",
+      "is-cell-changing",
+      "is-cell-selected",
+      "is-empty-cell",
+      "match-region",
+      "serve",
+      "server",
+      "solve-animated",
+      "track-piece",
+      "update",
+      "wait-for-cell-loaded"
+    ],
+    "solve_parser": [
+      "--puzzle-source",
+      "--retry-mode",
+      "--text-mode",
+      "api_key",
+      "api_provider",
+      "image_path",
+      "model"
+    ],
+    "exit_codes": {
+      "ok": 0,
+      "failure": 1,
+      "unsupported": 2,
+      "api_error": 3
+    }
+  },
+  "env": {
+    "CAPTCHAKRAKEN_BASE_URL": [
+      "mcp/src/index.ts"
+    ],
+    "CAPTCHAKRAKEN_CLIENT_NAME": [
+      "mcp/src/index.ts"
+    ],
+    "CAPTCHA_BASE_MODEL": [
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_DEBUG": [
+      "js/src/solver.ts",
+      "python/src/captchakraken/page_solver.py",
+      "python/src/captchakraken/planner.py",
+      "python/src/captchakraken/server_manager.py",
+      "python/src/captchakraken/solver.py"
+    ],
+    "CAPTCHA_HUMANIZATION": [
+      "js/src/humanize.ts",
+      "python/src/captchakraken/humanize.py"
+    ],
+    "CAPTCHA_KRAKEN_API_KEY": [
+      "js/src/cli-invocation.ts",
+      "js/src/solver.ts",
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_KRAKEN_AUTOSTART": [
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_KRAKEN_CLIENT": [
+      "python/src/captchakraken/planner.py"
+    ],
+    "CAPTCHA_KRAKEN_EXTRA_HEADERS": [
+      "python/src/captchakraken/planner.py"
+    ],
+    "CAPTCHA_KRAKEN_PYTHON": [
+      "js/scripts/setup-python.js",
+      "js/src/python-command.ts"
+    ],
+    "CAPTCHA_KRAKEN_PYTHON_SETUP_STRICT": [
+      "js/scripts/setup-python.js"
+    ],
+    "CAPTCHA_KRAKEN_SESSION": [
+      "python/src/captchakraken/page_solver.py",
+      "python/src/captchakraken/planner.py"
+    ],
+    "CAPTCHA_KRAKEN_SKIP_PYTHON_SETUP": [
+      "js/scripts/setup-python.js"
+    ],
+    "CAPTCHA_KRAKEN_STARTUP_TIMEOUT": [
+      "python/src/captchakraken/server_manager.py"
+    ],
+    "CAPTCHA_KRAKEN_STATE_DIR": [
+      "mcp/src/credentials.ts",
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_LORA_ADAPTER": [
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_LORA_NAME": [
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_LORA_REVISION": [
+      "python/src/captchakraken/config.py"
+    ],
+    "CAPTCHA_MAX_PIXELS": [
+      "python/src/captchakraken/prompts.py"
+    ],
+    "CAPTCHA_MIN_PIXELS": [
+      "python/src/captchakraken/prompts.py"
+    ],
+    "CAPTCHA_PIXEL_BOX_HALF": [
+      "python/src/captchakraken/solver.py"
+    ],
+    "CAPTCHA_PROMPTS_FILE": [
+      "python/src/captchakraken/prompts.py"
+    ],
+    "CAPTCHA_PROMPTS_NO_FETCH": [
+      "python/src/captchakraken/prompts.py"
+    ],
+    "CAPTCHA_REQUEST_PRIORITY": [
+      "python/src/captchakraken/planner.py"
+    ],
+    "CAPTCHA_TIMINGS": [
+      "python/src/captchakraken/timing.py"
+    ],
+    "PYTHONPATH": [
+      "js/src/solver.ts"
+    ],
+    "VLLM_API_KEY": [
+      "js/src/solver.ts",
+      "python/src/captchakraken/config.py"
+    ],
+    "VLLM_BASE_URL": [
+      "python/src/captchakraken/config.py"
+    ],
+    "VLLM_EXTRA_ARGS": [
+      "python/src/captchakraken/config.py"
+    ],
+    "VLLM_GPU_MEMORY_UTILIZATION": [
+      "python/src/captchakraken/config.py"
+    ],
+    "VLLM_MAX_LORA_RANK": [
+      "python/src/captchakraken/config.py"
+    ],
+    "VLLM_MAX_MODEL_LEN": [
+      "python/src/captchakraken/config.py"
+    ],
+    "VLLM_PORT": [
+      "python/src/captchakraken/config.py"
+    ],
+    "XDG_CONFIG_HOME": [
+      "mcp/src/credentials.ts"
+    ]
+  },
+  "model_resolution": {
+    "latest": "CaptchaKraken/CaptchaKraken-Lora-v1.2",
+    "registered_models": [
+      "CaptchaKraken/CaptchaKraken-Lora-v1.2",
+      "CaptchaKraken/CaptchaKrakenV1_Lora",
+      "CaptchaKraken/CaptchaKraken_v1.1",
+      "CaptchaKraken/Sunlight-AWQ-4bit",
+      "CaptchaKraken/Sunlight-v1.2-AWQ-4bit",
+      "CaptchaKraken/Twilight-FP8",
+      "CaptchaKraken/Twilight-v1.2-FP8"
+    ],
+    "latest_prompt_version": "2",
+    "pinned_fallback_fields": [
+      "base_model",
+      "lora_adapter",
+      "lora_name",
+      "lora_revision",
+      "prompt_sha256"
+    ]
+  },
+  "parity": {
+    "_comment": [
+      "Where the two ports genuinely differ. Rule 1c says they must behave the",
+      "same; these are the places they do not, recorded so the list can only",
+      "shrink. A NEW divergence fails js/src/contract.test.ts.",
+      "",
+      "None of these is fixed here. Each is a breaking change to one port or the",
+      "other and belongs in its own commit with the version bump it deserves —",
+      "which is exactly the decision this file exists to force someone to make.",
+      "",
+      "python_only_config: solver knobs the Python PageSolverConfig has and",
+      "CaptchaKrakenConfig does not, so the behaviour is unreachable from JS.",
+      "The three `slide_*` ones are the slider correction loop; a JS caller",
+      "cannot tune it. `max_unsupported_resolves`, `max_stale_frame_resolves`",
+      "and `stale_frame_resolve_enabled` DO exist in TS — spelled `Re`Solves,",
+      "which is not the snake->camel transform every other field follows, so a",
+      "caller porting a config between the two ports gets a silently ignored",
+      "option rather than a type error.",
+      "",
+      "js_only_config: options with no Python twin. onStep/repoPath/",
+      "pythonCommand exist because the TS port SPAWNS the Python one and Python",
+      "has nothing to spawn; idleMouseWander is a real behaviour gap."
+    ],
+    "python_only_config": [
+      "animated_probe_enabled",
+      "max_stale_frame_resolves",
+      "max_unsupported_resolves",
+      "slide_max_corrections",
+      "slide_probe_offsets_px",
+      "slide_tolerance_px",
+      "stale_frame_resolve_enabled"
+    ],
+    "js_only_config": [
+      "apiKey",
+      "idleMouseWander",
+      "maxStaleFrameReSolves",
+      "maxUnsupportedReSolves",
+      "model",
+      "onStep",
+      "pythonCommand",
+      "repoPath",
+      "staleFrameReSolveEnabled"
+    ]
+  },
+  "js": {
+    "package": {
+      "name": "captchakraken",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "bin": null,
+      "files": [
+        "dist",
+        "python",
+        "scripts",
+        "LICENSE"
+      ],
+      "postinstall": "node scripts/setup-python.js"
+    },
+    "exports": [
+      "AppiumTouchBackend",
+      "BaseHumanizer",
+      "CaptchaKrakenAPIError",
+      "CaptchaKrakenSolver",
+      "CdpTouchBackend",
+      "HUMANIZATION_MODES",
+      "MobileHumanizer",
+      "MouseHumanizer",
+      "NullHumanizer",
+      "PAUSE_KINDS",
+      "TouchscreenTouchBackend",
+      "fromPuppeteer",
+      "resolveHumanizer",
+      "resolveLoraName",
+      "touchBackendFor",
+      "watchPage"
+    ],
+    "humanization_modes": [
+      "mobile",
+      "mouse",
+      "none"
+    ],
+    "config_fields": [
+      "animatedChallengeAfterMs",
+      "apiKey",
+      "elementScreenshotTimeoutMs",
+      "gridLoadPollIntervalMs",
+      "gridLoadTimeoutMs",
+      "hcaptchaImagesTimeoutMs",
+      "humanization",
+      "humanizer",
+      "idleMouseWander",
+      "keyframeWaitPollMs",
+      "keyframeWaitTimeoutMs",
+      "maxNoProgressRounds",
+      "maxSolveLoops",
+      "maxStaleElementRetries",
+      "maxStaleFrameReSolves",
+      "maxUnsupportedReSolves",
+      "model",
+      "onStep",
+      "overallSolveTimeoutMs",
+      "postSolveDelayMs",
+      "postSolveOutcomePollMs",
+      "postSolveOutcomeTimeoutMs",
+      "postSubmitChangeTimeoutMs",
+      "pythonCommand",
+      "recaptchaDynamicFadePollMs",
+      "recaptchaDynamicFadeWaitMs",
+      "recaptchaFadeOnsetGraceMs",
+      "recaptchaMaxDynamicRounds",
+      "recaptchaTileHoverEnabled",
+      "repoPath",
+      "settleDiffThreshold",
+      "settleFrames",
+      "settlePollMs",
+      "settleTimeoutMs",
+      "staleElementBackoffMs",
+      "staleFrameDiffThreshold",
+      "staleFrameReSolveEnabled",
+      "startingMousePosition",
+      "touchDriver",
+      "touchTransform",
+      "videoBurstDurationMs",
+      "videoBurstFps",
+      "videoExtraInferenceMs",
+      "videoSolveEnabled"
+    ],
+    "solve_result_fields": [
+      "finalMousePosition",
+      "isSolved",
+      "tokenUsage"
+    ],
+    "error_codes": [
+      "account_suspended",
+      "insufficient_credits",
+      "invalid_api_key",
+      "invalid_request",
+      "missing_api_key",
+      "rate_limited",
+      "request_too_large",
+      "solve_abandoned",
+      "unrecognized_prompt",
+      "upstream_unavailable"
+    ],
+    "mcp_package": {
+      "name": "captchakraken-mcp",
+      "bin": {
+        "captchakraken-mcp": "dist/index.js"
+      },
+      "main": null
+    }
+  },
+  "mcp": {
+    "server_name": "captchakraken",
+    "tools": {
+      "create_api_key": {
+        "properties": [
+          "name"
+        ],
+        "required": []
+      },
+      "get_account": {
+        "properties": [],
+        "required": []
+      },
+      "get_balance": {
+        "properties": [],
+        "required": []
+      },
+      "get_models": {
+        "properties": [],
+        "required": []
+      },
+      "get_pricing": {
+        "properties": [],
+        "required": []
+      },
+      "get_topup_link": {
+        "properties": [
+          "usd"
+        ],
+        "required": []
+      },
+      "get_usage": {
+        "properties": [
+          "days"
+        ],
+        "required": []
+      },
+      "list_api_keys": {
+        "properties": [],
+        "required": []
+      },
+      "revoke_api_key": {
+        "properties": [
+          "id"
+        ],
+        "required": [
+          "id"
+        ]
+      },
+      "sign_in": {
+        "properties": [
+          "client_name"
+        ],
+        "required": []
+      },
+      "sign_out": {
+        "properties": [],
+        "required": []
+      }
+    }
+  }
+}

--- a/contract.json
+++ b/contract.json
@@ -26,17 +26,17 @@
       "solve_captcha_on_page"
     ],
     "signatures": {
-      "solve_captcha": "(media_path: str, instruction: str = '', *, puzzle_source: str = 'unknown', retry_mode: str | None = None, text_mode: bool = False, **kwargs: Any) -> Any",
-      "CaptchaSolver.__init__": "(self, model: str | None = None, provider: str = 'captchaKrakenApi', api_key: str | None = None)",
-      "CaptchaSolver.solve": "(self, media_path: str, instruction: str = '', puzzle_source: str = 'unknown', retry_mode: str | None = None, text_mode: bool = False) -> captchakraken.action_types.ClickAction | captchakraken.action_types.DragAction | captchakraken.action_types.TypeAction | captchakraken.action_types.WaitAction | captchakraken.action_types.DoneAction | List[captchakraken.action_types.ClickAction | captchakraken.action_types.DragAction | captchakraken.action_types.TypeAction | captchakraken.action_types.WaitAction | captchakraken.action_types.DoneAction]",
-      "CaptchaSolver.solve_keyframes": "(self, keyframe_paths: Sequence[str]) -> List[captchakraken.action_types.ClickAction | captchakraken.action_types.DragAction]",
-      "PageSolver.__init__": "(self, config: 'Optional[PageSolverConfig]' = None, solver: 'Optional[CaptchaSolver]' = None, **solver_kwargs: 'Any') -> 'None'",
-      "PageSolver.solve": "(self, page: 'Any') -> 'SolveResult'",
-      "PageSolver.watch": "(self, page: 'Any', **options: 'Any') -> \"'CaptchaWatcher'\"",
-      "solve_captcha_on_page": "(page: 'Any', **kwargs: 'Any') -> 'SolveResult'",
-      "CaptchaKrakenAPIError.__init__": "(self, message: str, *, status: int | None = None, code: str | None = None, resolution_url: str | None = None, retry_after_seconds: float | None = None)",
-      "add_overlays_to_image": "(image_path: str, boxes: list[dict], output_path: str = None, label_position='top-left')",
-      "humanize.resolve": "(config: 'Any') -> 'Humanizer'"
+      "solve_captcha": "(media_path, instruction='', *, puzzle_source='unknown', retry_mode=None, text_mode=False, **kwargs)",
+      "CaptchaSolver.__init__": "(self, model=None, provider='captchaKrakenApi', api_key=None)",
+      "CaptchaSolver.solve": "(self, media_path, instruction='', puzzle_source='unknown', retry_mode=None, text_mode=False)",
+      "CaptchaSolver.solve_keyframes": "(self, keyframe_paths)",
+      "PageSolver.__init__": "(self, config=None, solver=None, **solver_kwargs)",
+      "PageSolver.solve": "(self, page)",
+      "PageSolver.watch": "(self, page, **options)",
+      "solve_captcha_on_page": "(page, **kwargs)",
+      "CaptchaKrakenAPIError.__init__": "(self, message, *, status=None, code=None, resolution_url=None, retry_after_seconds=None)",
+      "add_overlays_to_image": "(image_path, boxes, output_path=None, label_position='top-left')",
+      "humanize.resolve": "(config)"
     },
     "page_solver_config_fields": [
       "animated_challenge_after_ms",

--- a/js/src/contract.test.ts
+++ b/js/src/contract.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The JS half of ../../contract.json, and the parity between the two ports.
+ *
+ * Project rule 1c: the Python and TypeScript clients must behave the same. Until
+ * now nothing checked it. No test imported `src/index.ts` at all, so the export
+ * list, `package.json`'s `main`/`types`/`postinstall`, and every field name in
+ * `CaptchaKrakenConfig` could be renamed and `npm test` stayed green — while the
+ * Python suite, equally, never looked at its own `__all__`.
+ *
+ * What the parity block below found on its first run is the argument for its
+ * existence: the two ports disagree on names that are not a snake_case↔camelCase
+ * transform (`max_unsupported_resolves` vs `maxUnsupportedReSolves`), on the
+ * shape of `SolveResult.tokenUsage`, and on which slider knobs exist at all.
+ * Those are pinned as KNOWN, not fixed here — fixing them is a breaking change
+ * to one port or the other and belongs in its own commit with a version bump.
+ * Pinning them means the list can only shrink deliberately, and a NEW divergence
+ * fails the build.
+ *
+ * Regenerate after an intended change:
+ *     CONTRACT_WRITE=1 npm test
+ * and commit the ../../contract.json diff — that diff is the deprecation note.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import * as pkg from './index';
+import { MODES } from './humanize';
+
+const ROOT = resolve(__dirname, '..', '..');
+const CONTRACT = resolve(ROOT, 'contract.json');
+const stored = JSON.parse(readFileSync(CONTRACT, 'utf8'));
+
+const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'js', 'package.json'), 'utf8'));
+const mcpJson = JSON.parse(readFileSync(resolve(ROOT, 'mcp', 'package.json'), 'utf8'));
+
+/** Field names of a TS interface, read out of the source. Types are erased at
+ *  runtime, and these names ARE the contract — a caller writes them by hand. */
+function interfaceFields(file: string, name: string): string[] {
+  const src = readFileSync(resolve(ROOT, 'js', 'src', file), 'utf8');
+  const start = src.indexOf(`export interface ${name} {`);
+  assert.notEqual(start, -1, `${name} is gone from ${file}`);
+  let depth = 0;
+  let i = src.indexOf('{', start);
+  const open = i;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) break;
+  }
+  const body = src.slice(open + 1, i);
+  // Top-level members only: `  name?: type;` at exactly two spaces of indent.
+  return [...body.matchAll(/^ {2}([A-Za-z_][A-Za-z0-9_]*)\??\s*:/gm)]
+    .map((m) => m[1])
+    .sort();
+}
+
+const live = {
+  package: {
+    name: packageJson.name,
+    main: packageJson.main,
+    types: packageJson.types,
+    bin: packageJson.bin ?? null,
+    files: packageJson.files,
+    postinstall: packageJson.scripts.postinstall,
+  },
+  exports: Object.keys(pkg).sort(),
+  // MODES is an ARRAY here and a dict in Python — a real divergence, harmless
+  // because both are only ever read as a set of names, and pinned as such.
+  humanization_modes: (Array.isArray(MODES) ? [...MODES] : Object.keys(MODES)).sort(),
+  config_fields: interfaceFields('types.ts', 'CaptchaKrakenConfig'),
+  solve_result_fields: interfaceFields('types.ts', 'SolveResult'),
+  error_codes: [
+    ...readFileSync(resolve(ROOT, 'js', 'src', 'errors.ts'), 'utf8')
+      .slice(
+        readFileSync(resolve(ROOT, 'js', 'src', 'errors.ts'), 'utf8').indexOf(
+          'export type CaptchaKrakenErrorCode',
+        ),
+      )
+      .split(';')[0]
+      .matchAll(/'([a-z_]+)'/g),
+  ]
+    .map((m) => m[1])
+    .sort(),
+  mcp_package: { name: mcpJson.name, bin: mcpJson.bin, main: mcpJson.main ?? null },
+};
+
+if (process.env.CONTRACT_WRITE === '1') {
+  writeFileSync(CONTRACT, JSON.stringify({ ...stored, js: live }, null, 2) + '\n');
+  console.log(`wrote ${CONTRACT}`);
+}
+
+test('the published JS surface has not moved', () => {
+  assert.deepEqual(
+    live,
+    stored.js,
+    'the JS half of the public contract changed. If that is intended, run ' +
+      '`CONTRACT_WRITE=1 npm test` in the same commit and bump the version the ' +
+      'change deserves; if not, put the name back — an alias beside the new one ' +
+      'costs nothing and keeps every published integration working.',
+  );
+});
+
+test('both ports offer the same humanization modes', () => {
+  // The one config value a caller passes as a literal string in both languages.
+  assert.deepEqual(live.humanization_modes, stored.python.humanization_modes);
+});
+
+test('both ports know the same API error codes', () => {
+  // These arrive from the gateway. A code either port cannot name is a refusal
+  // one of them will report as an unexplained failure.
+  assert.deepEqual(
+    live.error_codes.filter((c) => stored.python.error_codes.includes(c)).length,
+    stored.python.error_codes.length,
+    `Python knows ${JSON.stringify(stored.python.error_codes)}; JS knows ` +
+      `${JSON.stringify(live.error_codes)}. Every code one port branches on, ` +
+      `the other must too.`,
+  );
+});
+
+test('the two ports name the same solver options', () => {
+  // snake_case -> camelCase, with the exceptions pinned. The exceptions list is
+  // the point: each entry is a real divergence that a caller trips over, and it
+  // may only shrink.
+  const camel = (s: string) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+  const jsFields = new Set(live.config_fields);
+  const pyFields: string[] = stored.python.page_solver_config_fields;
+
+  const missingInJs = pyFields.filter((f) => !jsFields.has(camel(f)));
+  const known: string[] = stored.parity.python_only_config;
+  assert.deepEqual(
+    missingInJs.sort(),
+    [...known].sort(),
+    'a Python solver option has no TypeScript twin (or a known divergence was ' +
+      'fixed — shrink parity.python_only_config in contract.json). Rule 1c: the ' +
+      'two ports must behave the same, and a knob that exists in one is a ' +
+      'behaviour the other cannot reproduce.',
+  );
+
+  const pySet = new Set(pyFields.map(camel));
+  const extraInJs = live.config_fields.filter((f) => !pySet.has(f));
+  assert.deepEqual(extraInJs.sort(), [...stored.parity.js_only_config].sort());
+});

--- a/python/src/captchakraken/__init__.py
+++ b/python/src/captchakraken/__init__.py
@@ -95,4 +95,9 @@ __all__ = [
     "TouchscreenTouchBackend",
 ]
 
-__version__ = "2.6.0"
+# KEEP IN STEP with python/pyproject.toml and js/package.json — the two ports
+# ship together (rule 1c) and this is the only one importable code can read.
+# It said 2.6.0 while the wheel on PyPI said 2.6.1, so anyone gating on the
+# runtime attribute saw a version that had not been current for weeks.
+# tests/test_public_contract.py compares all three.
+__version__ = "2.6.1"

--- a/python/tests/test_public_contract.py
+++ b/python/tests/test_public_contract.py
@@ -86,8 +86,24 @@ _ENV_ROOTS = ("python/src", "js/src", "js/scripts", "mcp/src")
 
 
 def _sig(fn) -> str:
-    """A signature as text, so a moved `*` or a renamed parameter is a diff."""
-    return str(inspect.signature(fn))
+    """Parameter names, kinds and defaults — NOT annotations.
+
+    A moved `*`, a renamed parameter, a changed default and a removed argument
+    are all diffs here, which is the whole contract a caller depends on.
+
+    Annotations are deliberately stripped because their RENDERING is not stable
+    across interpreters: `inspect.signature` prints the same
+    `List[Union[ClickAction, DragAction]]` as `List[ClickAction | DragAction]`
+    on a newer Python, so a snapshot taken on 3.14 failed the 3.12 leg of the CI
+    matrix on the first run — a red gate reporting an interpreter version, not a
+    change to anything anyone ships. A gate that cries wolf about the machine it
+    ran on is a gate people learn to re-record without reading.
+    """
+    sig = inspect.signature(fn)
+    return str(sig.replace(
+        return_annotation=inspect.Signature.empty,
+        parameters=[p.replace(annotation=inspect.Parameter.empty)
+                    for p in sig.parameters.values()]))
 
 
 def _env_vars() -> dict:

--- a/python/tests/test_public_contract.py
+++ b/python/tests/test_public_contract.py
@@ -1,0 +1,316 @@
+"""The published surface, pinned. Breaking it has to be a decision.
+
+There are real paying customers on this client. Every name below is something
+someone's code says out loud — an import, a config key, a CLI flag, an
+environment variable, an error code — and renaming one is a silent break: their
+build still succeeds and the solve stops happening. Nothing in this repo
+previously noticed. The suite has thirty-odd behaviour tests and not one of them
+imports `captchakraken` at the package level or asserts the export list, so
+deleting a name from `__all__`, moving `solve_captcha`'s keyword-only boundary,
+or renaming `CAPTCHA_PROMPTS_FILE` was green.
+
+WHAT THIS IS NOT. It is not a second opinion on behaviour — the rest of the
+suite does that. It is a snapshot of NAMES and SHAPES, and its only job is to
+turn "someone renamed a thing" from a review note into a red build.
+
+WHEN IT FAILS, there are exactly two honest answers:
+
+  * you did not mean to → put the name back. Adding an alias beside the new
+    name is almost always the right move; removing one is a MAJOR version.
+  * you did mean to → run `python tests/test_public_contract.py --write` in the
+    SAME commit, and say in the message what breaks and what callers should do
+    instead. Bump the major version in pyproject.toml, js/package.json and
+    mcp/package.json as the change requires; the diff of ../../contract.json is
+    the deprecation note, and it is reviewable precisely because it is small.
+
+The JS half of the same file is checked by js/src/contract.test.ts and the MCP
+half by .github/scripts/mcp-smoke.mjs against a live handshake — one snapshot,
+three ports, so the two client libraries cannot drift from each other either
+(project rule 1c: Python and JS must behave the same).
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]          # CaptchaKraken/
+CONTRACT = REPO / "contract.json"
+PKG = REPO / "python" / "src" / "captchakraken"
+
+sys.path.insert(0, str(REPO / "python" / "src"))
+
+import captchakraken  # noqa: E402
+from captchakraken import config, errors, humanize, prompts  # noqa: E402
+from captchakraken.page_solver import PageSolverConfig  # noqa: E402
+
+# WHICH CHECKOUT ANSWERED. An editable install registers a meta-path finder,
+# and a meta-path finder beats `sys.path.insert(0, ...)`. So in a git worktree —
+# which is how every agent on this project works, with one shared venv pointed at
+# the main checkout — `import captchakraken` silently resolves to a DIFFERENT
+# tree than the one under test, and this file would pin a surface nobody is
+# about to publish. Caught the first time it was run from a worktree.
+assert Path(captchakraken.__file__).resolve().is_relative_to(REPO), (
+    f"imported captchakraken from {captchakraken.__file__}, which is outside "
+    f"{REPO}. This gate would be measuring a different checkout than the one "
+    f"being tested. Run it with that tree on the path first — "
+    f"`pip install -e python` inside this checkout, or "
+    f"PYTHONPATH={REPO / 'python' / 'src'}.")
+
+#: Every environment variable the client reads, anywhere in the tree. Found the
+#: same way a reader would — by grepping — so a new one cannot be added without
+#: this file noticing and the snapshot recording it.
+#:
+#: TWO patterns, and the second is not optional. Half the interesting variables
+#: are read through a module constant (`_PROMPTS_FILE_ENV = "CAPTCHA_PROMPTS_FILE"`,
+#: then `os.environ.get(_PROMPTS_FILE_ENV)`), so an inline-literal grep misses
+#: exactly the ones that matter most: CAPTCHA_PROMPTS_FILE, CAPTCHA_MIN_PIXELS,
+#: CAPTCHA_MAX_PIXELS and every routing header. A first pass at this file found
+#: 26 variables and silently omitted eight.
+_ENV_RE = re.compile(
+    r"""(?:os\.environ(?:\.get)?\(\s*|os\.getenv\(\s*|process\.env\.|process\.env\[\s*)"""
+    r"""["']?([A-Z][A-Z0-9_]{2,})["']?""")
+_ENV_CONST_RE = re.compile(
+    r"""^\s*(?:export\s+)?(?:const\s+)?_?[A-Z][A-Za-z0-9_]*\s*(?::[^=]+)?=\s*"""
+    r"""["']((?:CAPTCHA|VLLM|MIN_PIXELS|MAX_PIXELS)[A-Z0-9_]*)["']""", re.M)
+
+#: Read at runtime by the shipped client only. Test harnesses and example
+#: scripts read others (HEADLESS, CAMOUFOX_BINARY, …) and those are not a
+#: promise to anyone.
+_ENV_ROOTS = ("python/src", "js/src", "js/scripts", "mcp/src")
+
+
+def _sig(fn) -> str:
+    """A signature as text, so a moved `*` or a renamed parameter is a diff."""
+    return str(inspect.signature(fn))
+
+
+def _env_vars() -> dict:
+    found: dict[str, list[str]] = {}
+    for root in _ENV_ROOTS:
+        for path in sorted((REPO / root).rglob("*")):
+            if path.suffix not in (".py", ".ts", ".js", ".mjs") or ".test." in path.name:
+                continue
+            src = path.read_text(errors="ignore")
+            rel = path.relative_to(REPO).as_posix()
+            for name in _ENV_RE.findall(src) + _ENV_CONST_RE.findall(src):
+                if rel not in found.setdefault(name, []):
+                    found[name].append(rel)
+    return {k: sorted(v) for k, v in sorted(found.items())}
+
+
+def _cli_subcommands() -> list:
+    """The words `main()` dispatches on, read out of cli.py.
+
+    Dispatch is argv sniffing rather than argparse subparsers, so there is no
+    parser object to interrogate — the list lives in the `sys.argv[1] in {...}`
+    guards, and that is what this reads.
+    """
+    src = (PKG / "cli.py").read_text()
+    words = set()
+    # `sys.argv[1] != "serve"`, `sys.argv[1] not in {"fetch", "update"}`
+    for m in re.finditer(r"argv\[1\]\s*(?:!=|==)\s*[\"']([a-z][a-z0-9-]*)[\"']", src):
+        words.add(m.group(1))
+    for m in re.finditer(r"argv\[1\]\s+(?:not\s+)?in\s*[{(\[]([^})\]]*)[})\]]", src):
+        words |= set(re.findall(r"[\"']([a-z][a-z0-9-]*)[\"']", m.group(1)))
+    # `cmd = sys.argv[1]` then `if cmd == "x"` / `cmd not in {...}`
+    for m in re.finditer(r"\bcmd\s*(?:!=|==)\s*[\"']([a-z][a-z0-9-]*)[\"']", src):
+        words.add(m.group(1))
+    for m in re.finditer(r"\bcmd\s+(?:not\s+)?in\s*[{(\[]([^})\]]*)[})\]]", src):
+        words |= set(re.findall(r"[\"']([a-z][a-z0-9-]*)[\"']", m.group(1)))
+    return sorted(words)
+
+
+def _error_codes() -> list:
+    """The codes `errors._sentence` branches on.
+
+    These are the GATEWAY's strings arriving over the wire, and a caller
+    matching on them (retry on rate_limited, top up on insufficient_credits)
+    breaks when either side renames one. `code in ("a", "b")` has to be read as
+    two codes, not one — `invalid_api_key` only ever appears as the second half
+    of such a tuple, and a first pass at this dropped it.
+    """
+    src = (PKG / "errors.py").read_text()
+    out = set(re.findall(r'code\s*==\s*["\']([a-z_]+)["\']', src))
+    for group in re.findall(r'code\s+in\s*\(([^)]*)\)', src):
+        out |= set(re.findall(r'["\']([a-z_]+)["\']', group))
+    return sorted(out)
+
+
+def _solve_parser_flags() -> list:
+    """The default (no-subcommand) parser: the JS driver's entire interface."""
+    src = (PKG / "cli.py").read_text()
+    tail = src[src.index('parser = argparse.ArgumentParser(description="CaptchaKraken v2'):]
+    return sorted(set(re.findall(r'add_argument\(\s*\n?\s*"(--[a-z-]+|[a-z_]+)"', tail)))
+
+
+def surface() -> dict:
+    return {
+        "python": {
+            "version": captchakraken.__version__,
+            "exports": sorted(captchakraken.__all__),
+            "signatures": {
+                "solve_captcha": _sig(captchakraken.solve_captcha),
+                "CaptchaSolver.__init__": _sig(captchakraken.CaptchaSolver.__init__),
+                "CaptchaSolver.solve": _sig(captchakraken.CaptchaSolver.solve),
+                "CaptchaSolver.solve_keyframes": _sig(captchakraken.CaptchaSolver.solve_keyframes),
+                "PageSolver.__init__": _sig(captchakraken.PageSolver.__init__),
+                "PageSolver.solve": _sig(captchakraken.PageSolver.solve),
+                "PageSolver.watch": _sig(captchakraken.PageSolver.watch),
+                "solve_captcha_on_page": _sig(captchakraken.solve_captcha_on_page),
+                "CaptchaKrakenAPIError.__init__": _sig(errors.CaptchaKrakenAPIError.__init__),
+                "add_overlays_to_image": _sig(captchakraken.add_overlays_to_image),
+                "humanize.resolve": _sig(humanize.resolve),
+            },
+            "page_solver_config_fields": sorted(PageSolverConfig.__dataclass_fields__),
+            "solve_result_fields": sorted(
+                captchakraken.SolveResult.__dataclass_fields__),
+            "config_functions": sorted(
+                n for n, v in vars(config).items()
+                if callable(v) and not n.startswith("_")
+                and getattr(v, "__module__", "") == "captchakraken.config"),
+            # The codes `_sentence` branches on. These are the gateway's, and
+            # a caller matching on them (retry on rate_limited, top up on
+            # insufficient_credits) breaks when one is renamed on either side.
+            "error_codes": _error_codes(),
+            "humanization_modes": sorted(humanize.MODES),
+        },
+        "cli": {
+            "entry_point": "captchakraken = captchakraken.cli:main",
+            "subcommands": _cli_subcommands(),
+            "solve_parser": _solve_parser_flags(),
+            # Not introspectable — cli.py returns them as literals. Declared
+            # here because the JS driver branches on them: 2 means "this puzzle
+            # is unsupported, do not retry", 3 means "the API said no".
+            "exit_codes": {"ok": 0, "failure": 1, "unsupported": 2, "api_error": 3},
+        },
+        "env": _env_vars(),
+        "model_resolution": {
+            "latest": prompts.latest_model(),
+            "registered_models": sorted(prompts.registered_models()),
+            "latest_prompt_version": prompts.LATEST_PROMPT_VERSION,
+            "pinned_fallback_fields": sorted(config.pinned().keys() - {"_comment"}),
+        },
+    }
+
+
+# ── the gate ────────────────────────────────────────────────────────────────
+
+STORED = json.loads(CONTRACT.read_text())
+LIVE = surface()
+
+_FIX = ("\n\nIf this change is intended, run\n"
+        "    python python/tests/test_public_contract.py --write\n"
+        "in the same commit, bump the version the change deserves, and say in "
+        "the commit message what callers have to do instead. If it is not "
+        "intended, put the name back — an alias beside the new one costs "
+        "nothing and keeps every published integration working.")
+
+
+@pytest.mark.parametrize("section", ["python", "cli", "env", "model_resolution"])
+def test_the_published_surface_has_not_moved(section):
+    assert LIVE[section] == STORED[section], (
+        f"the {section!r} half of the public contract changed." + _FIX)
+
+
+def test_the_version_is_one_number_everywhere():
+    """`captchakraken.__version__` was 2.6.0 while the wheel published 2.6.1.
+
+    Anyone gating on the runtime attribute — the only one importable code can
+    see — read a version that had not been released for weeks.
+    """
+    pyproject = (REPO / "python" / "pyproject.toml").read_text()
+    declared = re.search(r'^version = "([^"]+)"', pyproject, re.M).group(1)
+    js = json.loads((REPO / "js" / "package.json").read_text())["version"]
+    assert captchakraken.__version__ == declared == js, (
+        f"captchakraken.__version__={captchakraken.__version__!r}, "
+        f"pyproject={declared!r}, js/package.json={js!r}. The two ports ship "
+        f"together (rule 1c) and the runtime attribute is the only one a "
+        f"caller can read.")
+
+
+def test_no_export_is_none_in_a_healthy_install():
+    """`__init__` degrades seven exports to None when the heavy deps are absent.
+
+    That is deliberate — importing the package must not explode on a
+    docs-only install. But it means `hasattr(captchakraken, "CaptchaSolver")`
+    is true on an install that cannot solve anything, so a compat check built
+    on hasattr would pass on a broken wheel. Assert the value, not the name.
+    """
+    missing = [n for n in captchakraken.__all__ if getattr(captchakraken, n) is None]
+    assert not missing, (
+        f"{missing} imported as None — the ModuleNotFoundError guard in "
+        f"__init__.py fired, so this environment is missing the client's own "
+        f"dependencies. `pip install -e python`.")
+
+
+def test_a_client_with_no_models_json_still_resolves_a_model(monkeypatch):
+    """Clients too old to ship models.json resolve through pinned_model.json.
+
+    models.json arrived after the first releases, so those wheels have no
+    registry at all: `prompts._load_registry` returns {} and every `config.*`
+    getter has to fall through to the pinned manifest. If that path ever raises,
+    an upgrade of THIS repo breaks clients that were already installed — the one
+    class of break a published package can never take back.
+    """
+    monkeypatch.delenv("CAPTCHA_LORA_ADAPTER", raising=False)
+    monkeypatch.delenv("CAPTCHA_LORA_NAME", raising=False)
+    monkeypatch.delenv("CAPTCHA_LORA_REVISION", raising=False)
+    monkeypatch.delenv("CAPTCHA_BASE_MODEL", raising=False)
+    monkeypatch.setattr(prompts, "_load_registry", dict)
+    prompts.clear_cache()
+    config.pinned.cache_clear()
+    try:
+        assert prompts.registered_models() == {}, "premise: no registry"
+        pinned = json.loads((PKG / "pinned_model.json").read_text())
+        assert config.lora_adapter() == pinned["lora_adapter"]
+        assert config.lora_name() == pinned["lora_name"]
+        assert config.base_model() == pinned["base_model"]
+        assert config.lora_revision() == pinned["lora_revision"]
+        # And it still produces prompts rather than raising: the built-in
+        # generation is the floor, not the registry.
+        assert prompts.resolve(pinned["lora_adapter"]).version
+    finally:
+        prompts.clear_cache()
+        config.pinned.cache_clear()
+
+
+def test_an_unregistered_model_name_falls_back_loudly_not_silently(capsys):
+    """A `candidate-<run_id>` adapter is not in models.json and has no `/`.
+
+    So registry lookup misses, the Hub step is skipped, and the client answers
+    with `latest`'s prompt generation. That mispairing is invisible in a solve
+    and looks exactly like a catastrophic model regression — reCAPTCHA 3x3 at
+    0.300 against a pinned 0.953 on training run 20260805-002154. It cannot be
+    made to work from here (the client has no way to know what a candidate was
+    trained on), so the contract is that it WARNS. Silence is the bug.
+    """
+    prompts.clear_cache()
+    ps = prompts.resolve("candidate-20260805-002154")
+    warning = capsys.readouterr().err
+    assert "not in models.json" in warning and "register it" in warning, (
+        f"resolving an unregistered adapter said nothing. It fell back to a "
+        f"prompt generation nobody chose, which is the failure that reported "
+        f"reCAPTCHA 3x3 at 0.300 against a pinned 0.953. stderr was: "
+        f"{warning!r}")
+    assert ps.version == prompts.registered_models()[
+        prompts.latest_model()]["prompt_version"]
+    prompts.clear_cache()
+
+
+if __name__ == "__main__":
+    if "--write" in sys.argv:
+        # MERGED, not overwritten: the js/ and mcp/ halves of this file are
+        # produced by their own ports and must survive a Python re-snapshot.
+        doc = json.loads(CONTRACT.read_text()) if CONTRACT.exists() else {}
+        doc.update(surface())
+        CONTRACT.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+        print(f"wrote {CONTRACT}")
+        subprocess.run(["git", "--no-pager", "diff", "--stat", str(CONTRACT)])
+    else:
+        print(json.dumps(surface(), indent=2, ensure_ascii=False))


### PR DESCRIPTION
There are real paying customers on this client, and nothing checked the names their code says out loud. No test imported the package at the top level or asserted the export list, so renaming an export, moving a keyword-only boundary, dropping a CLI flag or renaming an environment variable was green — on both ports. That break is silent for a user: their build still succeeds and the solve stops happening.

## What is pinned

`contract.json`, one snapshot with three checkers:

| Surface | Checked by |
|---|---|
| Python `__all__`, signatures, `PageSolverConfig` fields, `SolveResult` fields, config getters, error codes, humanization modes | `python/tests/test_public_contract.py` |
| JS exports, `package.json` main/types/files/postinstall, `CaptchaKrakenConfig` fields, error codes | `js/src/contract.test.ts` |
| The 11 MCP tools, their input schemas and required fields | `.github/scripts/mcp-smoke.mjs`, against a live handshake |
| CLI subcommands, the solve parser's flags, exit codes | `test_public_contract.py` |
| Every env var read anywhere in the tree (34, including the eight read through module constants — `CAPTCHA_PROMPTS_FILE`, `CAPTCHA_MIN_PIXELS`, `CAPTCHA_MAX_PIXELS`, the routing headers) | `test_public_contract.py` |
| `models.json` resolution **and the `pinned_model.json` fallback for clients too old to ship it** | `test_public_contract.py` |

Three checkers over one file means the two ports cannot drift from each other either (rule 1c).

## Two real breaks found by writing it

- **`__version__` said `2.6.0` while the wheel on PyPI said `2.6.1`.** The runtime attribute is the only version importable code can read, and it had been wrong for weeks. Fixed; all three version strings are now compared.
- **A pull request into `dev` here ran no CI whatsoever.** Both workflows trigger on `branches: [main]` only — #16's only check was GitGuardian. Work landed on the integration branch ungated and first met CI at the `dev → main` promotion, where a failure blocks the *release* rather than the change that caused it. `ci.yml` is hermetic and runs on free ubuntu-latest minutes, so there was never a cost argument for the narrower trigger.

**`tier3-request.yml` is deliberately NOT widened** — it dispatches the one contended Mac runner every Tier 3 in the project serialises behind.

## The MCP smoke test could not fail

It asserted `names.length > 0`. Ten of eleven tools could vanish, or `revoke_api_key` lose its `id`, and it exited 0 having reported the absence as a shorter list nobody reads. It now compares names and input schemas; verified it exits 1 on a renamed tool and on a removed one.

## `parity` is a list of real divergences, recorded so it can only shrink

Writing the cross-port check found three places the ports already disagree:

- `slide_tolerance_px`, `slide_probe_offsets_px`, `slide_max_corrections`, `animated_probe_enabled` exist only in Python — the slider correction loop is untunable from JS.
- `max_unsupported_resolves` → `maxUnsupportedReSolves` (and two siblings) is **not** the snake→camel transform every other field follows, so a caller porting a config between ports gets a silently ignored option rather than a type error.
- `SolveResult.tokenUsage` is a different shape in each.

**None is fixed here.** Each is a breaking change to one port and deserves its own commit with a version bump; this PR only makes them visible and stops a *new* one appearing.

## What a reviewer should check

- **Is the `parity` list the right verdict?** I chose to record the divergences rather than fix them, because fixing them inside a "add a contract test" PR would be a breaking change smuggled into a test change. If you would rather one of them were fixed now, say which.
- The contract deliberately pins **names and shapes, not prose** — MCP tool descriptions and help strings can be reworded freely.
- `test_public_contract.py` asserts the imported `captchakraken` comes from *this* checkout. An editable install registers a meta-path finder that beats `sys.path.insert`, so in a git worktree the gate would otherwise measure a different tree — it did, the first time it ran.
- Regeneration is `python python/tests/test_public_contract.py --write` plus `CONTRACT_WRITE=1` for the JS and MCP halves; the `contract.json` diff is the deprecation note.

`promote.yml` adds the `source branch` check the cloud and gateway repos have carried since 2026-08-22: `main` accepts merges from `dev` only. This repo publishes to npm and PyPI on every push to `main`, under a version number that can never be reused, which made it the most irreversible `main` of the four and the least protected. `main` now also requires the MCP build, which it publishes and was not gating.

Verified: `pytest -q` in `python/` and `npm test` in `js/` both green (123 JS tests pass); the MCP contract checked against a live stdio handshake. Companion PR: JWriter20/CaptchaKrakenFinetune#16.