### PR TITLE
A model can say its weights are not downloadable, and the client acts on it

### DIFF
--- a/python/src/captchakraken/models.json
+++ b/python/src/captchakraken/models.json
@@ -135,12 +135,14 @@
       "kind": "lora",
       "base_model": "Qwen/Qwen3.8-27B",
       "lora_name": "abyss",
-      "note": "IN DEVELOPMENT. Never published, never downloadable — see `availability`. Registered before it exists so the licence gates are armed rather than retrofitted after the first artifact is sitting on a disk: the publisher, the parity gate and `captchakraken fetch` all read this entry, and a rule added the day it is first needed is a rule that was absent on the day it was first needed. prompt_version is 2 because that is what src.synthetic.reasoning.instructions.PROMPT_VERSION builds training data at today; it is confirmed from training_runs/<run_id>/model.json when it trains, and until then nothing resolves it — there is no served_aliases entry, so no caller can name it."
+      "note": "IN DEVELOPMENT. Never published, never downloadable — see `availability`. Registered before it exists so the licence gates are armed rather than retrofitted after the first artifact is sitting on a disk: the publisher, the parity gate and `captchakraken fetch` all read this entry, and a rule added the day it is first needed is a rule that was absent on the day it was first needed. prompt_version is 2 because that is what the training data is built at today; CONFIRM IT from the training run's record when it trains, because a licence holder DOES name this model — it has a served_aliases entry (`abyss`), which is what makes their prompts resolve from this entry rather than through the `latest` fallback. Being nameable is not being downloadable: `availability` above is what refuses the weights, and the two are independent on purpose."
     }
   },
   "served_aliases": {
     "_comment": "A hosted endpoint serves a bare name, not a repo id. Map it back so prompt resolution works for callers who only ever see the alias. api.captchakraken.com now serves ONE model behind the permanent public name `captcha`, whatever the caller sends, so `captcha` means whichever adapter is current there — today CaptchaKraken-Lora-v1.2 — and NOT the v1.1 weights that share the name as a local vLLM alias. Self-hosters resolve by repo id via CAPTCHA_LORA_ADAPTER and are unaffected. Move this in the same change as the gateway's CKGATE_UPSTREAM_MODEL or the hosted model answers a prompt generation it was not trained on.",
     "captcha": "CaptchaKraken/CaptchaKraken-Lora-v1.2",
-    "captcha-v12": "CaptchaKraken/CaptchaKraken-Lora-v1.2"
+    "captcha-v12": "CaptchaKraken/CaptchaKraken-Lora-v1.2",
+    "_comment_abyss": "`abyss` is here for the OPPOSITE reason to the two above, and it is not a contradiction of `availability: licensed`. An alias says which model a served NAME means; availability says whether its weights can be downloaded. A licence holder does name this model — the hosted API accepts it from a licensed key and lists it to them on /v1/models so their SDK can — and without this line `canonical_model_id('abyss')` is None, so their prompts resolve through the `latest` fallback: the exact model/generation mispairing this file exists to prevent, silent, and only accidentally right while `latest` happens to share the generation. It does NOT make the weights fetchable; `captchakraken fetch` reads availability and refuses this name, which is also the clear error a self-hoster who typed it deserves.",
+    "abyss": "CaptchaKraken/Abyss"
   }
 }

--- a/python/src/captchakraken/models.json
+++ b/python/src/captchakraken/models.json
@@ -47,7 +47,25 @@
     "",
     "Omit it and the client keeps its historical behaviour (floor at 448 squared,",
     "no ceiling). Absent means UNKNOWN, not zero — set it only where it has been",
-    "measured or the training run is known."
+    "measured or the training run is known.",
+    "",
+    "`availability` says whether the WEIGHTS are obtainable. Two values:",
+    "  \"public\"   — on the Hub; anyone may download and self-host it. This is",
+    "               the default when the field is absent, so every entry that",
+    "               predates the field keeps its meaning exactly.",
+    "  \"licensed\" — NOT downloadable by anyone. Reachable only through",
+    "               api.captchakraken.com, or by a holder of a licence we issue.",
+    "               There is no Hub repo to point CAPTCHA_LORA_ADAPTER at, and",
+    "               `captchakraken fetch` refuses rather than 404ing at the Hub.",
+    "",
+    "Why it lives HERE and not only in a policy doc: this file is already the one",
+    "place that decides what an unpinned client downloads and what prompts it",
+    "sends. A second list of 'models you may not publish' kept somewhere else",
+    "would be a list that drifts, and the drift is silent in the direction that",
+    "costs the most. The finetune repo's publisher reads this field and REFUSES",
+    "to upload a licensed model to the Hub; check_prompt_parity.py refuses to let",
+    "`latest` be one, because an unpinned self-hoster would resolve to weights",
+    "they cannot obtain."
   ],
   "latest": "CaptchaKraken/CaptchaKraken-Lora-v1.2",
   "models": {
@@ -110,6 +128,14 @@
       "kind": "merged",
       "lora_name": "captcha",
       "note": "Ships its own prompts.json; this entry keeps it resolvable offline."
+    },
+    "CaptchaKraken/Abyss": {
+      "availability": "licensed",
+      "prompt_version": "2",
+      "kind": "lora",
+      "base_model": "Qwen/Qwen3.8-27B",
+      "lora_name": "abyss",
+      "note": "IN DEVELOPMENT. Never published, never downloadable — see `availability`. Registered before it exists so the licence gates are armed rather than retrofitted after the first artifact is sitting on a disk: the publisher, the parity gate and `captchakraken fetch` all read this entry, and a rule added the day it is first needed is a rule that was absent on the day it was first needed. prompt_version is 2 because that is what src.synthetic.reasoning.instructions.PROMPT_VERSION builds training data at today; it is confirmed from training_runs/<run_id>/model.json when it trains, and until then nothing resolves it — there is no served_aliases entry, so no caller can name it."
     }
   },
   "served_aliases": {

--- a/python/src/captchakraken/prompts.py
+++ b/python/src/captchakraken/prompts.py
@@ -247,6 +247,48 @@ def canonical_model_id(model: Optional[str]) -> Optional[str]:
     return alias if isinstance(alias, str) else None
 
 
+# ── availability: can these weights be obtained at all? ─────────────────────
+#
+# Same registry, same reason as prompt_version and pixel_budget: it is a fact
+# about the MODEL, and the one place that already decides what an unpinned
+# client downloads. See models.json's header comment.
+
+PUBLIC = "public"
+LICENSED = "licensed"
+#: Anything outside this set is a typo, and a typo must not read as "public".
+#: The whole class of bug this file exists to prevent is a field that fails
+#: open — `check_prompt_parity.py` rejects an unknown value at release time,
+#: and `is_licensed` below treats one as licensed rather than guessing.
+#:
+#: Spelled out as literals rather than `(PUBLIC, LICENSED)`: the release gate
+#: reads this file by AST so it can run in a training venv with no client
+#: installed, and `ast.literal_eval` cannot follow a name. A tuple of names
+#: reads as "unset" to the gate, which is the check silently not running.
+#: `tests/test_prompt_registry.py` pins that all three constants agree.
+AVAILABILITIES = ("public", "licensed")
+
+
+def availability(model: Optional[str]) -> str:
+    """`"public"` or `"licensed"` for `model`. Absent field means public.
+
+    An unregistered model is public too: it is not ours, and refusing to
+    download a stranger's adapter because we have never heard of it would break
+    every self-hoster who trained their own.
+    """
+    entry = registered_models().get(canonical_model_id(model) or "") or {}
+    value = entry.get("availability")
+    return value if isinstance(value, str) and value else PUBLIC
+
+
+def is_licensed(model: Optional[str]) -> bool:
+    """True if these weights are not obtainable — hosted API or licence only.
+
+    Fails CLOSED on an unrecognised value. A registry that says `"licenced"`
+    must not hand out a proprietary model because of a spelling.
+    """
+    return availability(model) != PUBLIC
+
+
 # ── prompt sets ─────────────────────────────────────────────────────────────
 
 @dataclass

--- a/python/src/captchakraken/updater.py
+++ b/python/src/captchakraken/updater.py
@@ -75,6 +75,35 @@ def _pip_upgrade_cmd() -> "list[str]":
     return [sys.executable, "-m", "pip", "install", "--upgrade", *ENGINE_PACKAGES]
 
 
+class LicensedModelError(RuntimeError):
+    """Raised when `fetch` is pointed at weights that are not downloadable."""
+
+
+def _refuse_licensed(repo_id: str) -> None:
+    """A licensed model has no Hub repo. Say so, instead of 404ing at the Hub.
+
+    Without this the failure is `RepositoryNotFoundError` from huggingface_hub,
+    which reads as "you are not logged in" or "typo" — so the next thing a
+    self-hoster does is hunt for a token that will never exist. It is also the
+    one place a licensed model's name can plausibly be typed by accident:
+    CAPTCHA_LORA_ADAPTER takes any string and `fetch` hands it straight to the
+    Hub.
+    """
+    from . import prompts
+
+    if not prompts.is_licensed(repo_id):
+        return
+    raise LicensedModelError(
+        f"{repo_id} is a LICENSED model: its weights are not published and "
+        "there is nothing at that Hub id to download.\n"
+        "  Reach it through the hosted API (https://api.captchakraken.com), "
+        "which needs no weights at all,\n"
+        "  or ask us about a self-hosting licence: https://captchakraken.com/contact\n"
+        "  To fetch a downloadable model instead, unset CAPTCHA_LORA_ADAPTER "
+        "or point it at a published one."
+    )
+
+
 def plan(
     *,
     weights: bool = True,
@@ -84,10 +113,20 @@ def plan(
     lora: "str | None" = None,
 ) -> dict:
     """Assemble the fetch plan WITHOUT running anything. Pure + side-effect-free
-    so `--dry-run` and the tests can assert exactly what a real run would do."""
+    so `--dry-run` and the tests can assert exactly what a real run would do.
+
+    Raises `LicensedModelError` rather than planning a download that cannot
+    succeed. Refusing HERE and not at the download call is deliberate: `plan()`
+    is what `--dry-run` prints, so the refusal is visible before anyone runs the
+    real thing, and there is exactly one place to keep it correct.
+    """
     base_model = base or config.base_model()
     lora_adapter = lora or config.lora_adapter()
     base_url = config.base_url()
+
+    if weights:
+        _refuse_licensed(lora_adapter)
+        _refuse_licensed(base_model)
 
     repos = [lora_adapter, base_model] if weights else []
     return {

--- a/python/tests/test_licensed_models.py
+++ b/python/tests/test_licensed_models.py
@@ -1,0 +1,128 @@
+"""A licensed model is named, resolved and refused — never quietly approximated.
+
+`availability: "licensed"` in models.json says the weights are not on the Hub:
+the model is reachable through the hosted API or a licence, and by no other
+route. Two client-side consequences follow, and this file pins both.
+
+**Fetching it must refuse, not 404.** Without the refusal the failure is
+huggingface_hub's `RepositoryNotFoundError`, which reads as "you are not logged
+in" or "typo" — so the next thing a self-hoster does is hunt for a token that
+will never exist. `CAPTCHA_LORA_ADAPTER` takes any string, which makes it the
+one place a licensed name is plausibly typed by accident.
+
+**Naming it must resolve its prompts from its own entry.** This is the half
+that was missing: the gateway lets a licensed account send `model: "abyss"` and
+lists the name to them on /v1/models precisely so their SDK can, but the client
+had no `served_aliases` entry for it — so `canonical_model_id("abyss")` was
+None and prompt resolution fell through to the `latest` branch. That is the
+mispairing models.json exists to prevent (CLAUDE.md §3e), and it is silent: it
+happens to land on the same generation today only because `latest` is on 2, and
+would become wrong the moment either side moves without the other.
+"""
+import pytest
+
+from captchakraken import prompts, updater
+
+LICENSED_REPO = "CaptchaKraken/Abyss"
+LICENSED_SERVED = "abyss"
+PUBLIC_REPO = "CaptchaKraken/CaptchaKraken-Lora-v1.2"
+
+
+# ── the registry states it ──────────────────────────────────────────────────
+
+def test_the_licensed_model_is_registered_as_licensed():
+    """Everything below keys off this one field."""
+    assert prompts.availability(LICENSED_REPO) == prompts.LICENSED
+    assert prompts.is_licensed(LICENSED_REPO)
+
+
+def test_a_published_model_is_public():
+    """A guard that refuses everything is a guard that gets deleted."""
+    assert prompts.availability(PUBLIC_REPO) == prompts.PUBLIC
+    assert not prompts.is_licensed(PUBLIC_REPO)
+
+
+def test_an_unregistered_model_is_public():
+    """Not ours, so not ours to refuse — a self-hoster's own adapter must fetch."""
+    assert not prompts.is_licensed("some-stranger/their-own-lora")
+
+
+def test_an_unrecognised_availability_reads_as_licensed(monkeypatch):
+    """Fails CLOSED. A registry that says "licenced" must not hand out a
+    proprietary model over a spelling; the release gate rejects the typo."""
+    monkeypatch.setattr(prompts, "_REGISTRY", {
+        "models": {"org/m": {"availability": "licenced"}}})
+    assert prompts.is_licensed("org/m")
+
+
+# ── the served name is the name a licence holder actually sends ─────────────
+
+def test_the_served_name_resolves_to_the_licensed_entry():
+    """`abyss` is what the caller writes; the gateway lists it to them.
+
+    Without the alias this is None, and every lookup below silently answers for
+    a model the registry has never heard of.
+    """
+    assert prompts.canonical_model_id(LICENSED_SERVED) == LICENSED_REPO
+
+
+def test_the_served_name_carries_its_own_prompt_generation():
+    """The mispairing models.json exists to prevent.
+
+    Asserted as "the same PromptSet the repo id gives", not as a version
+    number: the point is that both spellings of one model answer identically,
+    which stays true when the model retrains onto a new generation.
+
+    `source` is asserted too, because equality alone would also hold if BOTH
+    spellings fell through to the `latest` fallback — which is the bug, not the
+    fix, and today's `latest` happens to share the generation.
+    """
+    assert prompts.resolve(LICENSED_SERVED) == prompts.resolve(LICENSED_REPO)
+    assert prompts.resolve(LICENSED_SERVED).source == f"registry:{LICENSED_REPO}"
+
+
+def test_the_served_name_is_licensed_too():
+    """`CAPTCHA_LORA_ADAPTER=abyss` is at least as likely a typo as the repo id."""
+    assert prompts.is_licensed(LICENSED_SERVED)
+
+
+# ── fetching it refuses, and says what to do instead ────────────────────────
+
+def test_fetch_refuses_a_licensed_adapter():
+    with pytest.raises(updater.LicensedModelError) as exc:
+        updater.plan(lora=LICENSED_REPO)
+    message = str(exc.value)
+    # Must say what to do instead, not merely no.
+    assert "api.captchakraken.com" in message
+    assert "licence" in message
+
+
+def test_fetch_refuses_the_served_name_as_well():
+    with pytest.raises(updater.LicensedModelError):
+        updater.plan(lora=LICENSED_SERVED)
+
+
+def test_fetch_refuses_a_licensed_base_model():
+    """`--base` is a separate flag and would otherwise be an unguarded way in."""
+    with pytest.raises(updater.LicensedModelError):
+        updater.plan(base=LICENSED_REPO)
+
+
+def test_the_refusal_happens_in_plan_so_dry_run_shows_it():
+    """`plan()` is what `--dry-run` prints. Refusing at the download instead
+    would let `--dry-run` report a plan that cannot possibly succeed."""
+    with pytest.raises(updater.LicensedModelError):
+        updater.plan(lora=LICENSED_REPO, engine=False)
+
+
+def test_skipping_the_weights_skips_the_refusal():
+    """`fetch --engine-only` downloads nothing, so there is nothing to refuse.
+
+    A guard that fired here would block a licence holder from upgrading vLLM,
+    which is not what any of this is about.
+    """
+    assert updater.plan(weights=False, lora=LICENSED_REPO)["downloads"] == []
+
+
+def test_a_public_model_still_fetches():
+    assert updater.plan(lora=PUBLIC_REPO)["lora_adapter"] == PUBLIC_REPO


### PR DESCRIPTION
Adds `availability` to `models.json` and makes the client honour it. Part of the
Abyss licensing work; the private half (the publisher's refusal, the gateway
routing, the control-plane column) is in the other three repos.

## What changed

- **`models.json`** gains `availability`: `"public"` (the default when absent, so
  every existing entry keeps its exact meaning) or `"licensed"` — not on the Hub,
  reachable only through the hosted API or a licence.
- **`prompts.availability` / `prompts.is_licensed`** read it, and **fail CLOSED**
  on a value they do not recognise. A registry that said `"licenced"` must not
  hand out a proprietary model over a spelling.
- **`updater.plan()`** refuses a licensed repo id up front, with a message that
  says what to do instead. Without it the failure is huggingface_hub's
  `RepositoryNotFoundError`, which reads as "you are not logged in" — so the next
  thing a self-hoster does is hunt for a token that will never exist.
- **`CaptchaKraken/Abyss` is registered**, including a served alias `abyss`.

## What a reviewer should check

1. **The alias is not a contradiction.** `availability` says whether the WEIGHTS
   can be downloaded; a served alias says which model a NAME means. A licence
   holder does send `model: "abyss"` — the hosted API accepts it from a licensed
   key. Without the alias `canonical_model_id('abyss')` is None and their prompts
   resolve through the `latest` fallback: the model/generation mispairing this
   registry exists to prevent, silent, and right today only by coincidence.
   Four cases in `test_licensed_models.py` failed before the alias was added.
2. **The refusal does not over-reach.** An unregistered model is still public (a
   self-hoster's own adapter must fetch), and `fetch --engine-only` is not
   refused — a guard that stopped a licence holder upgrading vLLM would be
   solving nothing. Both are pinned.
3. **`latest` is unaffected**, and `check_prompt_parity.py` (private repo) now
   refuses to let `latest` ever be a licensed model, because an unpinned
   self-hoster would resolve to weights they cannot obtain.

## Verification

`python/tests/test_licensed_models.py` — 13 new cases, 4 confirmed failing before
the fix. `test_fetch_command.py`, `test_pinned_model.py`, `test_api_errors.py`
still pass (42 total). The private repo's prompt-parity gate passes with the new
entry and alias.

No model was published anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXLSqPXYDVSyis7X3c3kmJ