### PR TITLE
Nine waits a solve was paying for, and the instrument that found them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@ drive a phone, and no way to turn it off when your stack already did it.
 - **`startingMousePosition` is now honoured on the first gesture too.** The
   camoufox origin-seeding step used to overwrite it with the window centre.
 
+- **`SolveResult.phases`** — where a solve's wall clock went, in milliseconds
+  per phase (`detect`, `settle`, `inference`, `mouse`, `await-verdict`, …), on
+  both ports. The same partition `CAPTCHA_TIMINGS=1` prints to stderr, handed
+  back to you instead: "the solve took 12s" is not actionable and "the settle
+  monitor spent 4s of it" is. Phases nest, so one inside a differently-named one
+  counts under both — the cursor drifting over the widget *while* the model
+  generates is genuinely mouse time and inference time — and the totals can
+  therefore exceed the elapsed time.
+
+- **`stepScreenshotTimeoutMs`** (default 2000) — how long an `onStep`
+  observer's snapshot may take. Separate from `elementScreenshotTimeoutMs`,
+  which is sized for the picture the model reads. Ignored entirely when no
+  `onStep` is set.
+
 ### Changed
 
 - **The pointer position moved out of the solver** and into the humanizer, in
@@ -78,6 +92,33 @@ drive a phone, and no way to turn it off when your stack already did it.
   who turned humanisation off. An unknown name yields no wait rather than
   raising, so a new pause site cannot break a humanizer written against an older
   release.
+
+- **Solves are markedly faster, without moving any humanisation.** Nine waits
+  came out of the driver, all of them found by asking `SolveResult.phases`
+  where the time was going on solves that already *worked*. Across the full
+  fixture suite, both ports: median solve 6.8s -> 5.7s, p95 33.6s -> 21.6s.
+  No pause table, trajectory constant or gesture changed.
+
+  - the reCAPTCHA grid driver now reports the Verify press as an interaction,
+    so the caller polls for the vendor's verdict instead of taking the
+    no-interaction wait — and can no longer abort a correctly submitted answer
+    with "performed no interactions";
+  - its round 1 no longer re-waits for a grid the caller has just waited for;
+  - there is ONE wait after a round and it is polled, not slept: a round that
+    finished the captcha now ends when the widget goes, not 1200ms later;
+  - the widget's submit control is travelled to once, not twice;
+  - the planner keeps ONE pooled connection instead of re-dialling the endpoint
+    per inference (measured 258ms fresh vs 144ms pooled);
+  - `ensure_server` decides an endpoint is remote before asking it for /health.
+
+  Node-only, and the reason that port measured seconds slower per solve:
+  `scrollIntoViewIfNeeded` and the `onStep` observer's snapshot are both now
+  bounded (they inherited Playwright's 30s and the model's 8s budget, and both
+  wait for the widget to stop animating — 8.0s of one measured 12.0s solve);
+  the cursor drift during inference is interruptible; the interpreter and the
+  adapter name are resolved once per solver rather than per inference; and the
+  widget disappearing now ends the post-submit window for the eight vendors
+  that ship no response token, as it already did in Python.
 
 ## [2.6.0] - 2026-08-19
 

--- a/js/src/cli-resolution-is-memoised.test.ts
+++ b/js/src/cli-resolution-is-memoised.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Resolving the interpreter must not be paid per inference.
+ *
+ * `resolveCli()` ends in `resolvePythonCommand`, which — with nothing
+ * configured and no bundled venv, i.e. the plain `npm install` default —
+ * PROBES the interpreter with `spawnSync(cmd, ['--version'])`. spawnSync
+ * blocks the entire Node event loop: Playwright's socket pump, every timer,
+ * the humanizer's own pacing sleeps, all of it, for the length of a process
+ * start.
+ *
+ * It was called on every model call (`askModel`, `getAnimatedSolution`), every
+ * one-shot CV fallback and every CV-worker start — up to two blocking spawns
+ * per inference, to re-derive an answer that cannot change inside one process.
+ * `resolveLoraName` sat next to it doing a synchronous `readFileSync` of
+ * models.json, per inference, for the same reason.
+ *
+ * There is no way to observe a blocked event loop from a unit test, so what is
+ * pinned here is the property that makes it impossible: the resolution happens
+ * once and every later caller is handed the same answer back.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CaptchaKrakenSolver } from './solver';
+
+test('the interpreter is resolved once per solver', () => {
+  const s: any = new CaptchaKrakenSolver({ pythonCommand: process.execPath });
+  const first = s.resolveCli();
+  assert.strictEqual(s.resolveCli(), first,
+    'resolveCli() re-derived its answer — with no bundled venv that is a '
+    + 'blocking `python --version` spawn on the inference hot path');
+});
+
+test('the adapter name is read off disk once per solver', () => {
+  const s: any = new CaptchaKrakenSolver({ pythonCommand: process.execPath });
+  const { cliRoot } = s.resolveCli();
+  const first = s.loraName(cliRoot);
+
+  assert.equal(s.loraName(cliRoot), first);
+  assert.equal(s.loraNameCache, first,
+    'the resolved adapter name is not cached, so models.json is re-read '
+    + 'synchronously on every inference');
+});

--- a/js/src/idle-wander-stops-on-time.test.ts
+++ b/js/src/idle-wander-stops-on-time.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The cursor drift during inference must stop when the thinking stops.
+ *
+ * While the model generates, this port drifts the cursor over the challenge so
+ * the mouse behaves like a hand weighing the options instead of freezing. The
+ * drift loop is a move, then a human dwell of 180-540ms, repeat — and it was
+ * asked to stop by setting a flag the loop only reads BETWEEN dwells. So every
+ * inference ended with the solver waiting out a pause nobody was watching, on
+ * the one boundary where there is real work queued behind it: the answer has
+ * arrived and there is a tile to click.
+ *
+ * Paid once per model call, per round. The Python port pays none of it, because
+ * it does not wander at all — which is part of why the same fixture measured
+ * seconds slower on this port.
+ *
+ * The dwell is still 180-540ms of genuine idle time while the model is
+ * genuinely still thinking. All that changed is that it is interruptible.
+ *
+ * The test asks for the cheapest possible case: an answer that is ALREADY
+ * there. The drift loop opens with a 120-300ms pause before its first glance,
+ * so an uninterruptible one cannot hand back in under 120ms however fast the
+ * model was. Best of five, so a loaded box cannot make a broken build look
+ * fixed — only make a fixed one look broken, which fails loudly rather than
+ * quietly.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CaptchaKrakenSolver } from './solver';
+
+/** The shortest opening pause the drift loop takes before its first glance. */
+const MIN_OPENING_PAUSE_MS = 120;
+
+function wanderer() {
+  const solver: any = new CaptchaKrakenSolver({});
+  solver.human = { hovers: true, at: [0, 0], move: async () => {} };
+  return solver;
+}
+
+const element = { boundingBox: async () => ({ x: 0, y: 0, width: 300, height: 300 }) };
+
+test('an answer that is already there is handed back at once', async () => {
+  const runs: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const solver = wanderer();
+    const t0 = Date.now();
+    await solver.withIdleWander({}, element, async () => 'answer');
+    runs.push(Date.now() - t0);
+  }
+
+  const best = Math.min(...runs);
+  assert.ok(best < MIN_OPENING_PAUSE_MS, (
+    `the fastest of five runs took ${best}ms to hand back an answer that was `
+    + `already available. The drift loop's opening pause is ${MIN_OPENING_PAUSE_MS}-300ms `
+    + 'and it is not being woken, so every inference ends by waiting out a '
+    + 'pause with a click already queued behind it.'));
+});
+
+test('a humanizer with no cursor never drifts at all', async () => {
+  // Same rule as hoverCell: drifting a cursor that does not exist would emit
+  // mousemove at a touch-only widget. Kept here because the wake path must not
+  // become a new reason to enter the loop.
+  const solver = wanderer();
+  solver.human.hovers = false;
+  let moves = 0;
+  solver.human.move = async () => { moves += 1; };
+
+  await solver.withIdleWander({}, element, async () => {
+    await new Promise((r) => setTimeout(r, 50));
+  });
+  assert.equal(moves, 0);
+});

--- a/js/src/recaptcha-chipped-board.test.ts
+++ b/js/src/recaptcha-chipped-board.test.ts
@@ -160,3 +160,86 @@ test('a chip on a tile we did not click is not a verdict', async () => {
 
   assert.equal(seen.chipped, false);
 });
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Two things the grid driver was paying for twice, or not at all.
+ *
+ * Both were found in the phase budget of a solve that SUCCEEDED, which is why
+ * neither had ever shown up as a failure:
+ *
+ *     [BUDGET] solve 5.9s — 0.7s useful (11%), 5.3s waiting
+ *     [BUDGET]   grid-load                1.50s  x2      <- paid twice
+ *     [BUDGET]   post-submit-delay        1.48s  x1      <- should not exist
+ *
+ * 1. The Verify press is an INTERACTION, and this driver never said so. It sets
+ *    `performedAction` when it clicks a TILE; a round that answers `done`
+ *    clicks nothing, presses Verify and returns false. The caller reads that as
+ *    "this round did nothing", sleeps `postSolveDelayMs` flat instead of
+ *    polling for the verdict (~1s of dead time), and throws "performed no
+ *    interactions" if the widget has not finished tearing down — on an answer
+ *    that was correctly sent. Same bug `empty-answer-submits.test.ts` pins in
+ *    the OTHER driver; that one was fixed and this one was not.
+ *
+ * 2. The grid-load wait was paid twice, back to back. `solveSingle` waits for
+ *    the cells, reads the grid boxes off the loaded board, sees a 3x3 and hands
+ *    over here — whose round 1 opened by waiting for the same board again.
+ *    Rounds 2..N still wait, because by then this driver has clicked and the
+ *    tiles really are reloading.
+ *
+ * The Python half is `python/tests/test_grid_round_pays_once.py`.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** `driver`, plus a count of how many times the grid-load wait was paid. */
+function countingDriver(states: any, answers: any[]) {
+  const { solver, log } = driver(states, answers);
+  const counted = log as Log & { gridLoads: number };
+  counted.gridLoads = 0;
+  solver.waitForGridCellsLoaded = async () => { counted.gridLoads += 1; return true; };
+  return { solver, log: counted };
+}
+
+const CHIPPED = { empty: [], changing: [5], loaded: [1, 2, 3, 4, 6, 7, 8, 9], selected: [5] };
+const SWAPPING = { empty: [5], changing: [], loaded: [1, 2, 3, 4, 6, 7, 8, 9], selected: [] };
+
+test('a round that only presses Verify still reports an interaction', async () => {
+  const { solver, log } = countingDriver(CHIPPED, [DONE]);
+  const result = await solve(solver);
+
+  assert.deepEqual(log.clicked, [], 'the model said `done`; nothing should be clicked');
+  assert.equal(log.submits, 1, 'a `done` answer is submitted by pressing Verify');
+  assert.equal(result.didInteract, true,
+    'the driver pressed Verify and reported that it did nothing. The caller then '
+    + 'sleeps postSolveDelayMs instead of polling for the verdict, and throws '
+    + "'performed no interactions' if the widget has not vanished yet — on an "
+    + 'answer that was correctly sent.');
+});
+
+test('a round-cap exit still reports no interaction', async () => {
+  // The guard against "just return true". A board that keeps answering `wait`
+  // never submits and never clicks, so it genuinely did nothing — and the
+  // caller's infinite-loop guard is the only thing that ends it.
+  const { solver, log } = countingDriver(SWAPPING, [{ action: 'wait' }]);
+  const result = await solve(solver);
+
+  assert.equal(log.submits, 0, 'nothing was answered, so nothing may be submitted');
+  assert.equal(result.didInteract, false);
+});
+
+test('round one inherits the caller`s grid-load wait', async () => {
+  const { solver, log } = countingDriver(CHIPPED, [DONE]);
+  await solve(solver);
+
+  assert.equal(log.gridLoads, 0,
+    'round 1 waited for the grid to load; solveSingle has just done exactly '
+    + 'that and nothing has touched the board in between');
+});
+
+test('later rounds still wait for the board they changed', async () => {
+  const { solver, log } = countingDriver(SWAPPING, [CLICK_5, DONE]);
+  await solve(solver);
+
+  assert.equal(log.rounds, 2, 'a replaced tile has to be read once it lands');
+  assert.equal(log.gridLoads, 1,
+    'round 2 opens on a board this driver has just clicked, so it must wait for '
+    + 'the replacement to paint before the model reads it');
+});

--- a/js/src/scroll-into-view-is-bounded.test.ts
+++ b/js/src/scroll-into-view-is-bounded.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Scrolling to an element must not be allowed to take thirty seconds.
+ *
+ * `move()` calls `scrollIntoViewIfNeeded` before every gesture — once per
+ * action and once per submit. Playwright's default timeout is 30s, and it does
+ * not just scroll: it waits for the element to be STABLE, i.e. to stop
+ * animating. A captcha widget mid-animation is exactly the input that makes
+ * that wait run long, and the element is already on screen anyway, because the
+ * driver has just screenshotted it.
+ *
+ * MEASURED on mtcaptcha_text, fixture seed 20260730, this port:
+ *
+ *     [trial 1] SOLVED  12.0s
+ *         # 1 initial  +0.89s   @0.9s   initial (pre-action)
+ *         # 2 type     +10.13s  @11.0s  typed the code
+ *
+ *     phases: inference 1.5s, mouse 0.7s, settle 0.7s, verdict 0.1s
+ *
+ * Ten of those twelve seconds are in neither the model nor the mouse. They are
+ * one un-timed-out scroll to a text box that never moved. The Python port
+ * bounds it at 2000ms and has since it "turned a ~5s solve loop into minutes
+ * during live testing"; this port never got that fix, and the two ports must
+ * behave the same (CLAUDE.md 1c).
+ *
+ * On timeout the move proceeds to wherever `boundingBox()` says the element is,
+ * which is what it would have done anyway.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CaptchaKrakenSolver } from './solver';
+
+/** The longest a scroll may block a gesture. */
+const MAX_SCROLL_WAIT_MS = 3000;
+
+function solverWithFakePointer() {
+  const solver: any = new CaptchaKrakenSolver({});
+  const moves: Array<[number, number]> = [];
+  solver.human = { hovers: true, at: [0, 0], move: async (_p: any, to: [number, number]) => { moves.push(to); } };
+  return { solver, moves };
+}
+
+const boxed = (onScroll: (opts: any) => Promise<void>) => ({
+  scrollIntoViewIfNeeded: (opts: any) => onScroll(opts),
+  boundingBox: async () => ({ x: 10, y: 20, width: 100, height: 40 }),
+});
+
+test('the scroll before a gesture carries an explicit short timeout', async () => {
+  let seen: any = 'never called';
+  const { solver } = solverWithFakePointer();
+  await solver.move({}, boxed(async (opts) => { seen = opts; }));
+
+  assert.notEqual(seen, 'never called', 'move() no longer scrolls at all');
+  assert.ok(seen && typeof seen.timeout === 'number',
+    'scrollIntoViewIfNeeded was called with no timeout, so it inherits '
+    + "Playwright's 30s default and waits for the element to stop animating");
+  assert.ok(seen.timeout <= MAX_SCROLL_WAIT_MS,
+    `the scroll may block a gesture for ${seen.timeout}ms; the element is `
+    + 'already on screen, so anything past a couple of seconds is a wait for '
+    + 'an animation to end, not for a scroll to happen');
+});
+
+test('a scroll that times out still lets the gesture happen', async () => {
+  const { solver, moves } = solverWithFakePointer();
+  await solver.move({}, boxed(async () => { throw new Error('Timeout 2000ms exceeded.'); }));
+
+  assert.equal(moves.length, 1,
+    'a scroll that timed out aborted the whole gesture. The element is where '
+    + 'boundingBox says it is either way — failing here turns a slow scroll '
+    + 'into a failed solve.');
+});

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -862,9 +862,17 @@ export class CaptchaKrakenSolver {
       `step_${this.stepIndex}_${Date.now()}_${Math.floor(Math.random() * 1e9)}.png`,
     );
     try {
+      // ITS OWN, SHORT TIMEOUT — not `elementScreenshotTimeoutMs`, which is
+      // sized for the picture the MODEL reads and is 8s. This one is an
+      // observability snapshot, and `animations: 'disabled'` makes Playwright
+      // wait for the element to stop moving before it will take it. On a widget
+      // that is still animating that wait ran to the full 8s, per step:
+      // measured 8.0s of a 12.0s mtcaptcha_text solve, spent photographing a
+      // text box for a trace. An observer must never cost more than the action
+      // it is observing, and a missed frame in a trace costs nothing.
       await captchaElement.screenshot({
         path: screenshotPath,
-        timeout: this.config.elementScreenshotTimeoutMs ?? 8000,
+        timeout: this.config.stepScreenshotTimeoutMs ?? 2000,
         animations: 'disabled',
       });
     } catch {
@@ -3508,7 +3516,20 @@ export class CaptchaKrakenSolver {
       throw new Error(`Element not found: ${selectorOrElement}`);
     }
 
-    await elem.scrollIntoViewIfNeeded();
+    // BOUNDED. Playwright's default is 30s and it waits for the element to be
+    // STABLE — not animating — before it will scroll. This runs once per action
+    // and once per submit, so on a challenge that is mid-animation it burned
+    // the full default every time: measured 10.1s of a 12.0s mtcaptcha_text
+    // solve, spent scrolling to a text box that was already on screen. The
+    // element is on screen in every real case here (we just screenshotted it),
+    // so a short bound loses nothing: on timeout we move to wherever it is.
+    // page_solver.py has had this since it turned a ~5s solve loop into minutes
+    // in live testing; this port never got it.
+    try {
+      await elem.scrollIntoViewIfNeeded({ timeout: 2000 });
+    } catch {
+      /* an unscrolled element is still where boundingBox says it is */
+    }
 
     const box = await elem.boundingBox();
     if (!box) {

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -417,8 +417,11 @@ export class CaptchaKrakenSolver {
   /** The LoRA name models.json calls `latest`, read once. See askModel. */
   private loraNameCache: string | null = null;
 
-  /** Per-solve phase accounting; see timing.ts. Null outside a solve. */
-  private budget: PhaseBudget | null = null;
+  /**
+   * Phase accounting for the CURRENT or MOST RECENT solve; see timing.ts.
+   * Null before the first solve, and readable after a failed one.
+   */
+  budget: PhaseBudget | null = null;
 
   /**
    * Attribute the enclosed wall-clock to `name` for this solve's budget.
@@ -462,8 +465,12 @@ export class CaptchaKrakenSolver {
     } finally {
       // Printed on the way out of every solve, success or failure — a solve
       // that FAILED is exactly the one whose time you want itemised.
-      if (timingsEnabled()) console.error(this.budget.report());
-      this.budget = null;
+      if (timingsEnabled()) console.error(this.budget!.report());
+      // NOT cleared. A solve that FAILED is exactly the one whose time you want
+      // itemised, and by the time the caller catches the error the result — the
+      // only thing `phases` rides on — does not exist. `solve()` replaces it on
+      // entry, so the next solve cannot read the last one's. Same lifetime as
+      // page_solver.py's `_budget`.
       // Always shut the persistent CV worker down when a solve ends (success,
       // failure, or timeout) so we never leak a python process between solves.
       this.teardownCvWorker();

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -732,19 +732,30 @@ export class CaptchaKrakenSolver {
       renderWaits = 0;
       cumulativeTokenUsage.push(...tokenUsage);
 
-      // After acting, poll for the vendor's SOLVED signal (anchor checkbox
-      // checked / response token) for a short window before falling back to the
-      // normal re-detect. hCaptcha keeps the challenge iframe visible for a
-      // couple seconds while it verifies the final answer; without this, the
-      // loop re-entered the pipeline on that closing frame and burned ~18s
-      // (waitForHcaptchaChallengeImages timing out on a prompt-less frame).
-      // This ONLY early-returns on a definitive solved signal — it never
-      // re-solves, so it can't loop. If not solved in the window, the original
-      // detectCaptcha path below handles a genuine next round exactly as before.
+      // ONE wait after a round, polled, whichever kind of round it was.
+      //
+      // There used to be two: this poll when the round interacted, and a flat
+      // `delay(postSolveDelayMs + jitter)` when it did not. The flat sleep
+      // observed NOTHING — it ran to the end and only then asked whether the
+      // widget was still there — so a round that had in fact finished the
+      // captcha paid 1200-1500ms to find that out. The poll below already asks
+      // exactly that question and answers it the moment it becomes true.
+      //
+      // The two windows keep different LENGTHS, because different things size
+      // them: postSolveOutcomeTimeoutMs covers how late a vendor's success
+      // signal can arrive (measured — see types.ts), while postSolveDelayMs is
+      // the dwell a round that answered nothing takes before deciding the page
+      // has settled. Mirrors page_solver.py; the ports must not disagree about
+      // how long a round costs.
+      //
+      // hCaptcha keeps the challenge iframe visible for a couple of seconds
+      // while it verifies the final answer; without this window the loop
+      // re-entered the pipeline on that closing frame and burned ~18s. It ONLY
+      // early-returns on a definitive signal, so it cannot loop.
       const settleMs = didInteract
         ? (this.config.postSolveOutcomeTimeoutMs ?? 1000)
         : postSolveDelayMs + Math.random() * 300;
-      if (didInteract) {
+      {
         const deadline = Date.now() + settleMs;
         const verdictT0 = Date.now();
         let solved = false;
@@ -773,7 +784,8 @@ export class CaptchaKrakenSolver {
           if (await this.isChallengeFreshlyRendered(page)) break;
           await delay(this.config.postSolveOutcomePollMs ?? 75);
         }
-        this.budget?.add('await-verdict', Date.now() - verdictT0);
+        this.budget?.add(didInteract ? 'await-verdict' : 'post-submit-delay',
+                         Date.now() - verdictT0);
         // How long a SUCCESS actually took to show itself — the only number
         // that can size postSolveOutcomeTimeoutMs. A round that ends any other
         // way spends the whole window by construction.
@@ -785,8 +797,6 @@ export class CaptchaKrakenSolver {
             tokenUsage: aggregateTokenUsage(cumulativeTokenUsage),
           };
         }
-      } else {
-        await this.ph('post-submit-delay', () => delay(settleMs));
       }
 
       // Detect reCAPTCHA's under-selection error banner. If present, the

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { createHash, randomUUID } from 'crypto';
+import { PhaseBudget, timingsEnabled } from './timing';
 import { CaptchaKrakenConfig, SolverResult, ClickAction, DragAction, TypeAction, CaptchaAction, SolveResult, CliResponse, TokenUsage, Vector, SolveStepEvent } from './types';
 import { aggregateTokenUsage } from './token-usage';
 import { parseApiError } from './errors';
@@ -410,6 +411,25 @@ export class CaptchaKrakenSolver {
   // independent ones. Null outside a solve; ignored entirely when self-hosting.
   private solveSessionId: string | null = null;
 
+  /** Interpreter + CLI root, resolved once. See resolveCli. */
+  private cliCache: { cliRoot: string; py: string } | null = null;
+
+  /** The LoRA name models.json calls `latest`, read once. See askModel. */
+  private loraNameCache: string | null = null;
+
+  /** Per-solve phase accounting; see timing.ts. Null outside a solve. */
+  private budget: PhaseBudget | null = null;
+
+  /**
+   * Attribute the enclosed wall-clock to `name` for this solve's budget.
+   *
+   * A no-op outside a solve, so every helper stays callable from tests and from
+   * the watcher without a budget having been opened.
+   */
+  private ph<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    return this.budget ? this.budget.phase(name, fn) : fn();
+  }
+
   constructor(config: CaptchaKrakenConfig = {}) {
     this.config = config;
     this.human = resolveHumanizer({
@@ -432,9 +452,18 @@ export class CaptchaKrakenSolver {
 
   async solve(page: Page): Promise<SolveResult | void> {
     this.solveSessionId = randomUUID();
+    this.budget = new PhaseBudget();
     try {
-      return await this.solveImpl(page);
+      const result = await this.solveImpl(page);
+      // Attached HERE rather than at each of the four `isSolved:` sites, so a
+      // new early exit cannot forget it.
+      if (result) result.phases = this.budget.toObject();
+      return result;
     } finally {
+      // Printed on the way out of every solve, success or failure — a solve
+      // that FAILED is exactly the one whose time you want itemised.
+      if (timingsEnabled()) console.error(this.budget.report());
+      this.budget = null;
       // Always shut the persistent CV worker down when a solve ends (success,
       // failure, or timeout) so we never leak a python process between solves.
       this.teardownCvWorker();
@@ -564,7 +593,7 @@ export class CaptchaKrakenSolver {
         };
       }
 
-      const captchaElement = await this.detectCaptcha(page);
+      const captchaElement = await this.ph('detect', () => this.detectCaptcha(page));
       if (!captchaElement) {
         // Two-stage detection. detectCaptcha() returns null when there's no
         // VISIBLE, unsolved widget — but that splits into two cases:
@@ -631,7 +660,7 @@ export class CaptchaKrakenSolver {
             // it to settle before retrying; if it never settles it's animated.
             const el = await this.detectCaptcha(page);
             if (el) {
-              const s = await this.waitForElementSettled(el);
+              const s = await this.ph('settle', () => this.waitForElementSettled(el));
               if (s === 'animated') {
                 // Used to be terminal. Now it just means the next round is an
                 // animated puzzle: retry the loop and solveSingle takes the
@@ -717,14 +746,38 @@ export class CaptchaKrakenSolver {
         : postSolveDelayMs + Math.random() * 300;
       if (didInteract) {
         const deadline = Date.now() + settleMs;
+        const verdictT0 = Date.now();
         let solved = false;
+        let widgetGone = 0;
         while (Date.now() < deadline) {
           if (await this.isCaptchaSolved(page)) { solved = true; break; }
+          // The eight inline vendors have NO response token, so
+          // `isCaptchaSolved` — which reads only the hCaptcha and reCAPTCHA
+          // anchors — can never fire for them, and this loop ran out its whole
+          // window on EVERY round waiting for a signal that cannot arrive.
+          // "The widget is gone" is their completion signal and is already the
+          // authority immediately after this loop, so this only reaches the
+          // same verdict sooner — confirmed over two polls so a frame caught
+          // mid-swap between rounds cannot read as a solve. page_solver.py has
+          // had this since the geetest_v4_slide measurement (5.2s of a 12.3s
+          // solve, spent after the puzzle was already answered); this port had
+          // not, which is most of why it measured slower on those vendors.
+          if (!(await this.detectCaptcha(page))) {
+            widgetGone += 1;
+            if (widgetGone >= 2) { solved = true; break; }
+          } else {
+            widgetGone = 0;
+          }
           // A fresh next round has rendered → stop waiting, go solve it now
           // (keeps multi-round solves fast instead of burning the full window).
           if (await this.isChallengeFreshlyRendered(page)) break;
           await delay(this.config.postSolveOutcomePollMs ?? 75);
         }
+        this.budget?.add('await-verdict', Date.now() - verdictT0);
+        // How long a SUCCESS actually took to show itself — the only number
+        // that can size postSolveOutcomeTimeoutMs. A round that ends any other
+        // way spends the whole window by construction.
+        if (solved) console.log(`[verdict] success signal arrived after ${Date.now() - verdictT0}ms`);
         if (solved) {
           return {
             isSolved: true,
@@ -733,7 +786,7 @@ export class CaptchaKrakenSolver {
           };
         }
       } else {
-        await delay(settleMs);
+        await this.ph('post-submit-delay', () => delay(settleMs));
       }
 
       // Detect reCAPTCHA's under-selection error banner. If present, the
@@ -883,12 +936,12 @@ export class CaptchaKrakenSolver {
     if (puzzleSource === 'hcaptcha' && src && src.includes('frame=challenge')) {
       if (this.lastSubmitFrameHash) {
         this.setState(CaptchaState.Transitioning);
-        await this.waitForChangeSince(captchaElement, this.lastSubmitFrameHash);
+        await this.ph('await-next-round', () => this.waitForChangeSince(captchaElement, this.lastSubmitFrameHash as string));
         this.lastSubmitFrameHash = null;
       }
       this.setState(CaptchaState.Loading);
-      await this.waitForHcaptchaChallengeImages(captchaElement);
-      const settle = await this.waitForElementSettled(captchaElement);
+      await this.ph('hcaptcha-images', () => this.waitForHcaptchaChallengeImages(captchaElement));
+      const settle = await this.ph('settle', () => this.waitForElementSettled(captchaElement));
       if (settle === 'animated') {
         // A challenge that never settles is animated BY DESIGN — hCaptcha's
         // "select the odd animal" fades its sprites on independent cycles, and
@@ -920,7 +973,7 @@ export class CaptchaKrakenSolver {
       // moment we happened to catch. reCAPTCHA is excluded on purpose: it has its own
       // readiness gate below, its grids are never animated, and a second probe would
       // only add latency to a path that already works.
-      if (await this.waitForElementSettled(captchaElement) === 'animated') {
+      if (await this.ph('settle', () => this.waitForElementSettled(captchaElement)) === 'animated') {
         console.log('[animated] challenge never settles — recording it');
         isAnimated = true;
       }
@@ -956,7 +1009,7 @@ export class CaptchaKrakenSolver {
     // reCAPTCHA attempts into 3x3 vs 4x4 without scraping debug logs.
     let establishedGridSize: number | null = null;
     if (isRecaptchaChallenge) {
-      await this.waitForGridCellsLoaded(captchaElement);
+      await this.ph('grid-load', () => this.waitForGridCellsLoaded(captchaElement));
       // Only a 3x3 reCAPTCHA ever refreshes its tiles in place (blank/fade →
       // new image), so only a 3x3 can need the multi-round driver: click →
       // hover/wait for fades → re-solve. Whether THIS one does is decided inside
@@ -977,11 +1030,11 @@ export class CaptchaKrakenSolver {
 
     // 1. Take Screenshot
     const screenshotPath = path.join(os.tmpdir(), `captcha_${Date.now()}_${Math.floor(Math.random() * 1e9)}.png`);
-    await captchaElement.screenshot({
+    await this.ph('screenshot', () => captchaElement.screenshot({
       path: screenshotPath,
       timeout: this.config.elementScreenshotTimeoutMs ?? 8000,
       animations: 'disabled',
-    });
+    }));
 
     // Save image to debug directory if debugging is enabled
     this.saveImageForDebug(screenshotPath);
@@ -1010,15 +1063,15 @@ export class CaptchaKrakenSolver {
       //    a stale frame, so we re-screenshot and re-solve on the developed one.
       let response: CliResponse;
       if (isAnimated) {
-        burstDir = await this.recordKeyframeBurst(captchaElement);
-        response = await this.withIdleWander(page, captchaElement, () =>
-          this.getAnimatedSolution(burstDir as string));
+        burstDir = await this.ph('burst', () => this.recordKeyframeBurst(captchaElement));
+        response = await this.ph('inference', () => this.withIdleWander(page, captchaElement, () =>
+          this.getAnimatedSolution(burstDir as string)));
       } else {
-        response = await this.solveFrameFreshnessGuarded(
+        response = await this.ph('inference', () => this.solveFrameFreshnessGuarded(
           captchaElement, screenshotPath,
           (imagePath) => this.withIdleWander(page, captchaElement, () =>
             this.getSolution(imagePath, puzzleSource, retryMode, textMode)),
-        );
+        ));
       }
       const actions = response.actions;
       allTokenUsage = response.token_usage;
@@ -1130,12 +1183,14 @@ export class CaptchaKrakenSolver {
       // reach by construction. The press itself is bounded by
       // `shouldClickSubmit` below, which is where that hazard belongs.
       const lookup = frame ?? (slid ? null : scope);
-      if (lookup) {
-        verifyButton = await this.getVerifyButton(lookup);
-        if (verifyButton) {
-          await this.move(page, verifyButton);
-        }
-      }
+      if (lookup) verifyButton = await this.getVerifyButton(lookup);
+      // RESOLVED, not travelled to. `moveAndClick` below moves to the button
+      // itself, and it picks its own random point inside it — so moving here
+      // first bought a second humanised trajectory that ended a few dozen
+      // pixels from where the first one stopped, plus a second bounded
+      // scroll-into-view. Two hops to one button is slower AND is not
+      // something a hand does. A round that decides not to submit no longer
+      // walks to the control either.
       // 'done' actions fall through to the submit block below, same as before.
 
       // Submit policy: press the widget's own submit control whenever we have
@@ -1798,7 +1853,27 @@ export class CaptchaKrakenSolver {
    * falling back to the configured/`python` command. Throws if the CLI folder
    * is missing — callers that must not throw (e.g. runCliTool) wrap this.
    */
+  /**
+   * The adapter name models.json calls `latest`, resolved once per solver.
+   *
+   * `resolveLoraName` reads models.json (and pinned_model.json) off disk
+   * SYNCHRONOUSLY, and it was doing that on every inference for a file that
+   * cannot change inside one process.
+   */
+  private loraName(cliRoot: string): string {
+    if (this.loraNameCache === null) this.loraNameCache = resolveLoraName({ cliRoot });
+    return this.loraNameCache;
+  }
+
   private resolveCli(): { cliRoot: string; py: string } {
+    // MEMOISED. `resolvePythonCommand` probes the interpreter with a
+    // `spawnSync(cmd, ['--version'])`, which blocks the whole Node event loop —
+    // Playwright's socket pump and every timer with it — and this was called on
+    // EVERY inference, every CV fallback and every worker start. On the
+    // npm-install default (no bundled venv, nothing configured) that is up to
+    // two blocking process spawns per model call, for an answer that cannot
+    // change inside one process.
+    if (this.cliCache) return this.cliCache;
     const { repoPath, pythonCommand } = this.config;
     const cliRoot = repoPath ?? getBundledCliRoot();
     if (!fs.existsSync(cliRoot)) {
@@ -1816,7 +1891,8 @@ export class CaptchaKrakenSolver {
       venvPython: getVenvPython(cliRoot),
       exists: commandExists,
     });
-    return { cliRoot, py };
+    this.cliCache = { cliRoot, py };
+    return this.cliCache;
   }
 
   /**
@@ -2475,13 +2551,18 @@ export class CaptchaKrakenSolver {
 
     for (let round = 1; round <= maxRounds; round++) {
       // 1. Settle and screenshot.
-      await this.waitForGridCellsLoaded(captchaElement);
+      //
+      // Round 1 skips the wait: `solveSingle` has just paid it, read the grid
+      // boxes off the loaded board and handed over, and nothing has touched
+      // the widget in between. Rounds 2..N still wait, because by then THIS
+      // driver has clicked and the tiles really are reloading.
+      if (round > 1) await this.ph('grid-load', () => this.waitForGridCellsLoaded(captchaElement));
       const shotA = path.join(os.tmpdir(), `recap_${Date.now()}_${Math.floor(Math.random() * 1e9)}.png`);
       try {
         // Explicit timeout — after a Verify this element is being torn down,
         // and the 30s default waits for it to go stable first. See
         // screenshot-timeouts.test.ts.
-        await captchaElement.screenshot({ path: shotA, timeout: 2500, animations: 'disabled' });
+        await this.ph('screenshot', () => captchaElement.screenshot({ path: shotA, timeout: 2500, animations: 'disabled' }));
       } catch {
         // The board is gone. Stop driving rounds and let the outer loop
         // re-detect — which, having interacted, reads "nothing left" as solved.
@@ -2512,10 +2593,10 @@ export class CaptchaKrakenSolver {
         //    (the dynamic 3x3 puzzle is the case this matters most for).
         const retryForThisRound = pendingRetry;
         pendingRetry = null; // only the first round carries the inbound retry hint
-        const response = await this.solveFrameFreshnessGuarded(
+        const response = await this.ph('inference', () => this.solveFrameFreshnessGuarded(
           captchaElement, shotA,
           (imagePath) => this.getSolution(imagePath, 'recaptcha', retryForThisRound),
-        );
+        ));
         this.archiveLatestDebugRun(attempt, response.actions);
         allTokenUsage.push(...response.token_usage);
         const actionList = Array.isArray(response.actions) ? response.actions : [response.actions];
@@ -2540,8 +2621,10 @@ export class CaptchaKrakenSolver {
         // Tiles are still loading; the CLI explicitly told us NOT to submit.
         // Find what's loading, hover it, and wait for at least one to settle.
         console.log(`[recaptcha-grid] round ${round}: CLI says wait (${(action as any).duration_ms ?? 0}ms).`);
-        const { loading } = await this.watchClickedTiles(page, captchaElement, session, clickedOrder);
-        await this.waitForAnyClickedTileLoaded(page, captchaElement, session, loading);
+        await this.ph('fade-wait', async () => {
+          const { loading } = await this.watchClickedTiles(page, captchaElement, session, clickedOrder);
+          await this.waitForAnyClickedTileLoaded(page, captchaElement, session, loading);
+        });
         continue;
       }
 
@@ -2578,7 +2661,7 @@ export class CaptchaKrakenSolver {
         //    this board is answered) or go blank / fade out for a replacement
         //    (dynamic puzzle: read it again). reCAPTCHA's reply lags the click,
         //    so we watch a grace window, not a single instant-after snapshot.
-        const { loading, chipped } = await this.watchClickedTiles(page, captchaElement, session, clickedThisRound);
+        const { loading, chipped } = await this.ph('fade-wait', () => this.watchClickedTiles(page, captchaElement, session, clickedThisRound));
         if (chipped || !loading.length) {
           // Either the widget ticked our clicks and kept the photos — a board
           // that does that is fully answered by the round that clicked it — or
@@ -2592,7 +2675,7 @@ export class CaptchaKrakenSolver {
         // Tiles are reloading — wait (while hovering) for at least one to settle
         // before re-solving, so we don't feed the model a mid-fade grid.
         console.log(`[recaptcha-grid] round ${round}: tiles loading ${JSON.stringify(loading)}; waiting.`);
-        await this.waitForAnyClickedTileLoaded(page, captchaElement, session, loading);
+        await this.ph('fade-wait', () => this.waitForAnyClickedTileLoaded(page, captchaElement, session, loading));
         continue;
       }
 
@@ -2612,6 +2695,13 @@ export class CaptchaKrakenSolver {
         if (verifyButton) {
           console.log('[recaptcha-grid] clicking Verify to submit.');
           await this.moveAndClick(page, verifyButton);
+          // The press IS an interaction, and saying so is load-bearing: the
+          // caller polls for the vendor's verdict on a round that interacted
+          // and sleeps postSolveDelayMs flat on one that did not — and throws
+          // 'performed no interactions' if the widget outlives that sleep. A
+          // `done` round clicks no tile, so without this line the one answer
+          // shape that submits and nothing else reports having done nothing.
+          performedAction = true;
           await this.emitStep(captchaElement, 'submit', 'submitted (Verify)', 'recaptcha', 'challenge', attempt);
           // Snapshot the submitted frame, exactly as the one-shot path does.
           // Without it isChallengeFreshlyRendered reads the CLOSING board as a
@@ -2727,7 +2817,7 @@ export class CaptchaKrakenSolver {
     // the same place the Python port reads them. See model-name.ts.
     const { cliRoot, py } = this.resolveCli();
     const {
-      model = resolveLoraName({ cliRoot }),
+      model = this.loraName(cliRoot),
       apiKey = process.env.CAPTCHA_KRAKEN_API_KEY ?? process.env.VLLM_API_KEY,
     } = this.config;
 
@@ -2997,7 +3087,7 @@ export class CaptchaKrakenSolver {
     // resolveCli() FIRST — see getAnimatedSolution.
     const { cliRoot, py } = this.resolveCli();
     const {
-      model = resolveLoraName({ cliRoot }),
+      model = this.loraName(cliRoot),
       apiKey = process.env.CAPTCHA_KRAKEN_API_KEY ?? process.env.VLLM_API_KEY,
     } = this.config;
 
@@ -3353,10 +3443,22 @@ export class CaptchaKrakenSolver {
     const b = box;
 
     let stop = false;
+    // The dwell is INTERRUPTIBLE, and that is not a detail. `fn` is the model
+    // call; the moment it returns there is a click to make, and the finally
+    // below waits for this loop to notice. With a plain `delay` it noticed only
+    // when the timer ran out, so every inference was followed by up to 540ms of
+    // waiting for a pause nobody was watching — paid once per round, and the
+    // Python port pays none of it because it does not wander at all. Same
+    // wake-able-sleep shape as watcher.ts.
+    const waker: { fn: (() => void) | null } = { fn: null };
+    const nap = (ms: number) => new Promise<void>((resolve) => {
+      const timer = setTimeout(() => { waker.fn = null; resolve(); }, ms);
+      waker.fn = () => { clearTimeout(timer); waker.fn = null; resolve(); };
+    });
     const pad = 0.18; // keep drift inside the tile area, off the extreme edges
     const wander = (async () => {
       // brief pause before the first drift — don't lurch the instant we ask
-      await delay(120 + Math.random() * 180);
+      await nap(120 + Math.random() * 180);
       while (!stop) {
         const tx = b.x + b.width * (pad + Math.random() * (1 - 2 * pad));
         const ty = b.y + b.height * (pad + Math.random() * (1 - 2 * pad));
@@ -3366,7 +3468,7 @@ export class CaptchaKrakenSolver {
           break;
         }
         if (stop) break;
-        await delay(180 + Math.random() * 360); // human dwell between glances
+        await nap(180 + Math.random() * 360); // human dwell between glances
       }
     })();
 
@@ -3374,6 +3476,7 @@ export class CaptchaKrakenSolver {
       return await fn();
     } finally {
       stop = true;
+      waker.fn?.();
       await wander.catch(() => {});
     }
   }
@@ -3416,7 +3519,7 @@ export class CaptchaKrakenSolver {
 
   async moveAndClick(page: Page, element: ElementHandle) {
     await this.move(page, element);
-    await this.human.click(page, this.human.at);
+    await this.ph('mouse', () => this.human.click(page, this.human.at));
   }
 
   /**
@@ -3425,7 +3528,7 @@ export class CaptchaKrakenSolver {
    * nothing at all.
    */
   private async performSmoothMove(page: Page, x: number, y: number) {
-    await this.human.move(page, [x, y]);
+    await this.ph('mouse', () => this.human.move(page, [x, y]));
   }
 
   private async executeClick(
@@ -3468,7 +3571,7 @@ export class CaptchaKrakenSolver {
       return;
     }
 
-    await this.human.click(page, [elementBox.x + relativeX, elementBox.y + relativeY]);
+    await this.ph('mouse', () => this.human.click(page, [elementBox.x + relativeX, elementBox.y + relativeY]));
   }
 
   private async executeDrag(
@@ -3484,7 +3587,7 @@ export class CaptchaKrakenSolver {
     };
     const src = bboxCenter(action.source_bounding_box);
     const dst = bboxCenter(action.target_bounding_box);
-    await this.human.drag(page, [src.x, src.y], [dst.x, dst.y]);
+    await this.ph('mouse', () => this.human.drag(page, [src.x, src.y], [dst.x, dst.y]));
   }
 
   // ────────────────────────────────────────────────────────── typing + sliding

--- a/js/src/step-observer-is-cheap.test.ts
+++ b/js/src/step-observer-is-cheap.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Watching a solve must not slow it down.
+ *
+ * `onStep` hands the caller a screenshot at each stage. That snapshot was taken
+ * with `elementScreenshotTimeoutMs` — the budget sized for the picture the
+ * MODEL reads, 8s — and with `animations: 'disabled'`, which makes Playwright
+ * wait for the element to STOP MOVING before it will take it. A captcha widget
+ * that is still animating never stops, so the wait ran to the full budget, per
+ * step.
+ *
+ * MEASURED on mtcaptcha_text, fixture seed 20260730, with the timestamps
+ * printed from inside the round:
+ *
+ *     detect-done       59ms
+ *     screenshot-done  818ms
+ *     inference-done  2554ms
+ *     answerBox         12ms
+ *     moveAndClick     315ms
+ *     typeText         465ms
+ *     actions-done   11351ms      <- 8s of nothing, after the code was typed
+ *
+ * Eight seconds photographing a text box for a trace, on a solve whose actual
+ * work was three and a half. An observer must never cost more than the action
+ * it observes, and a missed frame in a trace costs nothing.
+ *
+ * The Python port has no onStep, so this was also a difference between the two
+ * ports that only showed up as latency (CLAUDE.md 1c).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CaptchaKrakenSolver } from './solver';
+
+/** The longest an observability snapshot may block a solve. */
+const MAX_STEP_SNAPSHOT_MS = 3000;
+
+function seen(config: Record<string, any> = {}) {
+  const shots: any[] = [];
+  const solver: any = new CaptchaKrakenSolver({ onStep: async () => {}, ...config });
+  const element = { screenshot: async (opts: any) => { shots.push(opts); } };
+  return { solver, element, shots };
+}
+
+test('the step snapshot has its own short budget', async () => {
+  const { solver, element, shots } = seen({ elementScreenshotTimeoutMs: 8000 });
+  await solver.emitStep(element, 'initial', 'x', 'unknown', 'challenge', 1);
+
+  assert.equal(shots.length, 1);
+  assert.ok(shots[0].timeout <= MAX_STEP_SNAPSHOT_MS,
+    `an onStep snapshot may block the solve for ${shots[0].timeout}ms. That is `
+    + "the model's screenshot budget, and this picture is a trace — with "
+    + 'animations disabled it waits for the widget to stop moving, which on an '
+    + 'animated challenge means the whole budget, on every step.');
+});
+
+test('the caller can still size it', async () => {
+  const { solver, element, shots } = seen({ stepScreenshotTimeoutMs: 500 });
+  await solver.emitStep(element, 'initial', 'x', 'unknown', 'challenge', 1);
+  assert.equal(shots[0].timeout, 500);
+});
+
+test('no observer, no snapshot', async () => {
+  // The whole cost is skipped for the ordinary caller, and must stay skipped.
+  const solver: any = new CaptchaKrakenSolver({});
+  const shots: any[] = [];
+  await solver.emitStep({ screenshot: async (o: any) => { shots.push(o); } },
+    'initial', 'x', 'unknown', 'challenge', 1);
+  assert.equal(shots.length, 0);
+});

--- a/js/src/timing.ts
+++ b/js/src/timing.ts
@@ -1,0 +1,100 @@
+/**
+ * Where one solve's wall-clock went, by phase.
+ *
+ * The TypeScript half of `python/src/captchakraken/timing.py`; the two are one
+ * implementation in two languages and `test_timing_parity.py` pins that they
+ * name the same phases. That parity is the point: without it the ports can only
+ * be compared on their totals, and "the JS port is four seconds slower" is not
+ * a bug report — "the JS port spends four seconds starting a Python
+ * interpreter it did not need to start" is.
+ *
+ * Always on. It is a few map updates per phase against multi-second waits, and
+ * a budget you have to opt into is one nobody has when the slow solve happens.
+ * Only PRINTED under `CAPTCHA_TIMINGS=1`; always RETURNED on `SolveResult`.
+ */
+
+/**
+ * What a phase's time COUNTS AS, when asking how much of a solve was useful.
+ *
+ * Only two kinds of second are worth spending: one the model is thinking in,
+ * and one the pointer is travelling in (which has to look human, so it cannot
+ * be rushed). Everything else is the driver waiting on a clock, and every such
+ * wait is a candidate for deletion or for overlapping with something real.
+ */
+export const PRODUCTIVE = new Set(['inference', 'mouse']);
+
+export function timingsEnabled(): boolean {
+  return process.env.CAPTCHA_TIMINGS === '1';
+}
+
+export class PhaseBudget {
+  readonly totals = new Map<string, number>();
+  readonly counts = new Map<string, number>();
+  private readonly open: string[] = [];
+  private readonly t0 = Date.now();
+
+  /**
+   * Attribute `fn`'s wall-clock to `name`.
+   *
+   * Phases may nest (a burst contains its screenshots). Only the OUTERMOST of a
+   * given NAME accumulates, so re-entering one cannot double-count it — but a
+   * phase nested inside a differently-named one counts under both, deliberately:
+   * the cursor drifting over the widget WHILE the model generates is genuinely
+   * both `mouse` and `inference`, and hiding either would misreport what the
+   * solve was doing. The totals are therefore an attribution, not a partition,
+   * and can exceed the elapsed time.
+   */
+  async phase<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    if (this.open.includes(name)) return fn();
+    this.open.push(name);
+    const t0 = Date.now();
+    try {
+      return await fn();
+    } finally {
+      this.open.splice(this.open.indexOf(name), 1);
+      this.add(name, Date.now() - t0);
+    }
+  }
+
+  /** Record a measured span directly, for blocks that would need re-indenting. */
+  add(name: string, ms: number): void {
+    this.totals.set(name, (this.totals.get(name) ?? 0) + ms);
+    this.counts.set(name, (this.counts.get(name) ?? 0) + 1);
+  }
+
+  elapsedMs(): number {
+    return Date.now() - this.t0;
+  }
+
+  /** Plain object for `SolveResult.phases`, with the solve total folded in. */
+  toObject(): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const [k, v] of this.totals) out[k] = v;
+    out.total = this.elapsedMs();
+    return out;
+  }
+
+  report(): string {
+    const total = this.elapsedMs();
+    let useful = 0;
+    for (const [k, v] of this.totals) if (PRODUCTIVE.has(k)) useful += v;
+    const rows = [...this.totals.entries()].sort((a, b) => b[1] - a[1]);
+    const lines = [
+      `[BUDGET] solve ${(total / 1000).toFixed(1)}s — ` +
+        `${(useful / 1000).toFixed(1)}s useful (${total ? Math.round((100 * useful) / total) : 0}%), ` +
+        `${((total - useful) / 1000).toFixed(1)}s waiting`,
+    ];
+    for (const [name, ms] of rows) {
+      const tag = PRODUCTIVE.has(name) ? '*' : ' ';
+      lines.push(
+        `[BUDGET] ${tag} ${name.padEnd(22)} ${(ms / 1000).toFixed(2).padStart(6)}s  x${this.counts.get(name)}`,
+      );
+    }
+    let attributed = 0;
+    for (const v of this.totals.values()) attributed += v;
+    if (total - attributed > 50) {
+      lines.push(`[BUDGET]   ${'(unattributed)'.padEnd(22)} ${((total - attributed) / 1000).toFixed(2).padStart(6)}s`);
+    }
+    return lines.join('\n');
+  }
+}

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -617,4 +617,14 @@ export interface SolveResult {
     cachedInputTokens: number;
     estimatedCost: number;
   };
+  /**
+   * Where this solve's wall-clock went, in milliseconds per phase — the same
+   * partition `CAPTCHA_TIMINGS=1` prints, handed to the caller instead of to
+   * stderr. Mirrors `SolveResult.phases` on the Python port.
+   *
+   * Returned rather than only logged because "the solve took 12s" is not
+   * actionable and "the settle monitor spent 4s of it" is, and a caller
+   * measuring a fleet cannot scrape another process's stderr.
+   */
+  phases?: Record<string, number>;
 }

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -487,6 +487,19 @@ export interface CaptchaKrakenConfig {
   elementScreenshotTimeoutMs?: number;
 
   /**
+   * How long an `onStep` observer's screenshot may take, ms (default 2000).
+   *
+   * Deliberately separate from `elementScreenshotTimeoutMs`, which is sized for
+   * the picture the MODEL reads. This one is a trace snapshot: it is taken with
+   * `animations: 'disabled'`, which makes Playwright wait for the element to
+   * stop moving first, and on a still-animating widget that ran to the full 8s
+   * on every step — 8.0s of a measured 12.0s solve. An observer must never cost
+   * more than the action it observes, and a missed frame in a trace costs
+   * nothing. Ignored entirely when no `onStep` is set.
+   */
+  stepScreenshotTimeoutMs?: number;
+
+  /**
    * After a submit, hCaptcha may replace the challenge iframe for the next
    * round, detaching the handle we just detected ("element is not visible").
    * This is a transition, not a dead puzzle: how many times to back off,

--- a/js/src/verdict-widget-gone.test.ts
+++ b/js/src/verdict-widget-gone.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The widget going away IS the success signal, for the vendors that have no other.
+ *
+ * After a submit the driver polls for a completion signal until
+ * `postSolveOutcomeTimeoutMs`. `isCaptchaSolved` reads the hCaptcha and
+ * reCAPTCHA anchors — a response token, a checked checkbox — and eight of the
+ * vendors this client drives render into the host page with no such token at
+ * all: GeeTest, Yidun, Tencent, Yandex, Lemin, Prosopo, MTCaptcha, BotDetect.
+ *
+ * So for those vendors this loop was waiting for something that cannot arrive,
+ * and spent the WHOLE window on every round — after the puzzle had already been
+ * answered, with the widget sitting there visibly solved. Measured in the
+ * Python port on geetest_v4_slide before it got this fix: 5.2s of a 12.3s
+ * solve. This port never got it, which is a large part of why it measured
+ * slower than Python on exactly those families.
+ *
+ * "The widget is gone" is already the authority the moment this loop ends —
+ * `detectCaptcha` is called immediately afterwards and a null there returns
+ * solved. Checking it INSIDE the loop therefore reaches the same verdict
+ * sooner and can reach no other one. It is confirmed over two consecutive
+ * polls, because between rounds a vendor swaps the challenge frame out and a
+ * single poll can catch that gap and call a re-deal a solve.
+ *
+ * The Python half is `page_solver.py`'s verdict loop, pinned by
+ * CaptchaKrakenFinetune's tests/test_verdict_window_is_measured.py; per
+ * CLAUDE.md 1c the two ports must behave the same.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CaptchaKrakenSolver } from './solver';
+
+/**
+ * A solver whose whole round is faked: one interacting round, then whatever
+ * `detect` says. Counts how many times the verdict loop asked anything, which
+ * is what tells a two-poll exit from a window burned to the end.
+ */
+function driver(detect: () => any) {
+  const solver: any = new CaptchaKrakenSolver({
+    postSolveOutcomeTimeoutMs: 1000,
+    postSolveOutcomePollMs: 5,   // no browser here; the count is the measurement
+  });
+  const log = { detects: 0, solvedChecks: 0 };
+
+  solver.human = { reset: async () => {}, at: [0, 0] };
+  solver.detectCaptcha = async () => { log.detects += 1; return detect(); };
+  solver.isCaptchaSolved = async () => { log.solvedChecks += 1; return false; };
+  solver.isChallengeFreshlyRendered = async () => false;
+  solver.hasRecaptchaUnderselectError = async () => false;
+  solver.solveSingle = async () => ({ didInteract: true, tokenUsage: [] });
+  return { solver, log };
+}
+
+test('two polls with the widget gone end the window', async () => {
+  // The widget is there when the round starts and gone from the first verdict
+  // poll on — an inline vendor that accepted the answer.
+  let calls = 0;
+  const { solver, log } = driver(() => (++calls <= 1 ? {} : null));
+  const result = await solver.solveImpl({});
+
+  assert.equal(result.isSolved, true);
+  // 1 to find the widget + 2 verdict polls. A window burned to the end would
+  // be ~200 at a 5ms poll.
+  assert.ok(log.detects <= 4,
+    `the verdict window asked ${log.detects} times; two consecutive "the widget `
+    + 'is gone" polls settle it, and waiting past that is time spent after the '
+    + 'puzzle was already answered');
+  assert.ok(log.solvedChecks <= 3,
+    `the response-token check ran ${log.solvedChecks} times; it can never fire `
+    + 'for a vendor that ships no token');
+});
+
+test('one gone poll is not a verdict', async () => {
+  // Between rounds hCaptcha swaps the challenge frame out, so a single poll can
+  // land in the gap. Calling that a solve would end the solve on a re-deal.
+  const seen = [{}, null, {}, {}, {}, {}, {}, {}];
+  let i = 0;
+  const { solver, log } = driver(() => (i < seen.length ? seen[i++] : {}));
+  // The widget never goes for good, so this ends on the loop cap, not a verdict.
+  await assert.rejects(() => solver.solveImpl({}));
+
+  assert.ok(log.detects > seen.length,
+    'a lone gone poll among present ones must not short-circuit the window');
+});

--- a/python/src/captchakraken/page_solver.py
+++ b/python/src/captchakraken/page_solver.py
@@ -3079,7 +3079,6 @@ class PageSolver:
             # about how long the window ought to be.
             if solved:
                 _log(f"[verdict] success signal arrived after {_verdict_ms:.0f}ms")
-            if solved:
                 return SolveResult(True, self._last_mouse, _aggregate(cumulative_usage))
 
             if self._has_recaptcha_underselect_error(page):

--- a/python/src/captchakraken/page_solver.py
+++ b/python/src/captchakraken/page_solver.py
@@ -163,6 +163,14 @@ class SolveResult:
     is_solved: bool
     final_mouse_position: Tuple[float, float]
     token_usage: List[Dict[str, Any]] = field(default_factory=list)
+    #: Where this solve's wall-clock went, in milliseconds per phase — the same
+    #: partition `CAPTCHA_TIMINGS=1` prints, handed to the caller instead of to
+    #: stderr. `{}` when the result was built outside a solve.
+    #:
+    #: Returned rather than only logged because "the solve took 12s" is not
+    #: actionable and "the settle monitor spent 4s of it" is, and a caller
+    #: measuring a fleet cannot scrape stderr from inside its own process.
+    phases: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -2313,19 +2321,29 @@ class PageSolver:
             # Each round can legitimately spend ~10s waiting on fades, so eight
             # of them plus the model calls can outlast the whole solve budget.
             self._check_deadline(f"recaptcha grid round {round_index}")
-            with self._phase("grid-load"):
-                self._wait_for_grid_cells_loaded(element)
+            # Round 1 skips it: `_solve_single` has just waited for these cells,
+            # read the grid boxes off the loaded board and handed over, and
+            # nothing has touched the widget in between. Rounds 2..N still wait,
+            # because by then THIS driver has clicked and the tiles really are
+            # reloading. Measured 2148ms x2 on one solve.
+            if round_index > 1:
+                with self._phase("grid-load"):
+                    self._wait_for_grid_cells_loaded(element)
             shot = _tmp_png("recap")
             action: Optional[Dict[str, Any]] = None
             try:
-                self._screenshot(element, shot, timeout_ms=cfg.element_screenshot_timeout_ms)
+                with self._phase("screenshot"):
+                    self._screenshot(element, shot,
+                                     timeout_ms=cfg.element_screenshot_timeout_ms)
                 retry_for_round = pending_retry
                 pending_retry = None  # only round 1 carries the inbound hint
-                actions, usage = self._solve_frame_freshness_guarded(
-                    element,
-                    shot,
-                    lambda image_path: self._get_solution(image_path, "recaptcha", retry_for_round),
-                )
+                with self._phase("inference"):
+                    actions, usage = self._solve_frame_freshness_guarded(
+                        element,
+                        shot,
+                        lambda image_path: self._get_solution(
+                            image_path, "recaptcha", retry_for_round),
+                    )
                 all_usage.extend(usage)
                 action = _as_dict(actions[0]) if actions else None
             finally:
@@ -2338,8 +2356,11 @@ class PageSolver:
 
             if action.get("action") == "wait":
                 _log(f"[recaptcha-grid] round {round_index}: waiting for tiles.")
-                loading, _ = self._watch_clicked_tiles(page, element, session, clicked_order)
-                self._wait_for_any_clicked_tile_loaded(page, element, session, loading)
+                with self._phase("fade-wait"):
+                    loading, _ = self._watch_clicked_tiles(
+                        page, element, session, clicked_order)
+                    self._wait_for_any_clicked_tile_loaded(
+                        page, element, session, loading)
                 continue
 
             if action.get("action") == "click":
@@ -2369,9 +2390,10 @@ class PageSolver:
                     f"-> cells {clicked_this_round}."
                 )
 
-                loading, chipped = self._watch_clicked_tiles(
-                    page, element, session, clicked_this_round
-                )
+                with self._phase("fade-wait"):
+                    loading, chipped = self._watch_clicked_tiles(
+                        page, element, session, clicked_this_round
+                    )
                 if chipped or not loading:
                     # Either the widget ticked our clicks and kept the photos
                     # (a board that does that is answered), or nothing faded
@@ -2383,7 +2405,9 @@ class PageSolver:
                     )
                     should_submit = True
                     break
-                self._wait_for_any_clicked_tile_loaded(page, element, session, loading)
+                with self._phase("fade-wait"):
+                    self._wait_for_any_clicked_tile_loaded(
+                        page, element, session, loading)
                 continue
 
             _log(f"[recaptcha-grid] round {round_index}: unexpected action; re-solving.")
@@ -2395,6 +2419,17 @@ class PageSolver:
                 if verify:
                     _log("[recaptcha-grid] clicking Verify to submit.")
                     self._move_and_click(page, verify)
+                    # The press IS an interaction, and saying so is load-bearing
+                    # — the same rule `_solve_single` learned on
+                    # prosopo_grid_3x3, in the other driver, on another day. A
+                    # `done` round clicks no tile, so without this the one
+                    # answer shape that submits and does nothing else reports
+                    # having done nothing: the caller then takes the
+                    # no-interaction wait instead of polling for the verdict
+                    # (~1s of dead time on every static reCAPTCHA), and raises
+                    # "performed no interactions" if the widget has not
+                    # finished tearing down — on an answer correctly sent.
+                    performed_action = True
 
         return performed_action, all_usage
 
@@ -2541,8 +2576,10 @@ class PageSolver:
 
             if not is_animated:
                 if not have_shot:
-                    self._screenshot(element, shot,
-                                     timeout_ms=self.config.element_screenshot_timeout_ms)
+                    with self._phase("screenshot"):
+                        self._screenshot(
+                            element, shot,
+                            timeout_ms=self.config.element_screenshot_timeout_ms)
                 with self._phase("inference"):
                     actions, all_usage = self._solve_frame_freshness_guarded(
                         element,
@@ -2650,11 +2687,16 @@ class PageSolver:
             # burning all ten solve loops on a puzzle they had answered on
             # the first one. The press itself is still bounded by
             # `should_submit` below, which is where the hazard belongs.
+            # RESOLVED, not travelled to. `_move_and_click` below moves to the
+            # button itself and picks its own random point inside it, so moving
+            # here first bought a second humanised trajectory that ended a few
+            # dozen pixels from where the first one stopped, plus a second
+            # bounded scroll-into-view. Two hops onto one button is slower AND
+            # is not something a hand does. A round that decides not to submit
+            # no longer walks to the control either.
             lookup = frame or (scope if not slid else None)
             if lookup is not None:
                 verify_button = self._get_verify_button(lookup)
-                if verify_button:
-                    self._move_to_element(page, verify_button)
 
             # Submit policy: press the widget's own submit control whenever we
             # have put an ANSWER into it — a selection, a placed piece, a typed
@@ -2761,7 +2803,12 @@ class PageSolver:
         previous_session = os.environ.get(_SESSION_ENV)
         os.environ[_SESSION_ENV] = str(uuid.uuid4())
         try:
-            return self._solve_impl(page, start, cumulative_usage)
+            result = self._solve_impl(page, start, cumulative_usage)
+            # Attached HERE rather than at each of the seven `return
+            # SolveResult(...)` sites, so a new early exit cannot forget it.
+            result.phases = dict(self._budget.totals)
+            result.phases["total"] = self._budget.elapsed_ms()
+            return result
         finally:
             # Printed on the way out of every solve, success or failure — a
             # solve that FAILED is exactly the one whose time you want itemised.
@@ -2965,60 +3012,75 @@ class PageSolver:
             render_waits = 0
             cumulative_usage.extend(usage)
 
-            if did_interact:
-                # Poll for the vendor's SOLVED signal before re-entering the
-                # pipeline. hCaptcha keeps the challenge visible for a couple of
-                # seconds while verifying; without this the loop re-solves that
-                # closing frame and burns ~18s. Only ever early-RETURNS on a
-                # definitive signal, so it cannot loop.
-                deadline = time.monotonic() * 1000.0 + cfg.post_solve_outcome_timeout_ms
-                solved = False
-                widget_gone = 0
-                _verdict_t0 = time.perf_counter()
-                while time.monotonic() * 1000.0 < deadline:
-                    if self.is_captcha_solved(page):
+            # ONE wait after a round, polled, whichever kind of round it was.
+            #
+            # There used to be two: this poll when the round interacted, and a
+            # flat `_delay(post_solve_delay_ms + jitter)` when it did not. The
+            # flat sleep observed NOTHING — it ran to the end and only then
+            # asked whether the widget was still there — so a round that had in
+            # fact finished the captcha paid 1200-1500ms to find that out. The
+            # poll below already asks exactly that question and answers it the
+            # moment it becomes true.
+            #
+            # The two windows keep different LENGTHS, because different things
+            # size them: `post_solve_outcome_timeout_ms` covers how late a
+            # vendor's success signal can arrive (measured — see the constant),
+            # while `post_solve_delay_ms` is the dwell a round that answered
+            # nothing takes before deciding the page has settled.
+            window_ms = (cfg.post_solve_outcome_timeout_ms if did_interact
+                         else cfg.post_solve_delay_ms + random.random() * 300)
+            # Poll for the vendor's SOLVED signal before re-entering the
+            # pipeline. hCaptcha keeps the challenge visible for a couple of
+            # seconds while verifying; without this the loop re-solves that
+            # closing frame and burns ~18s. Only ever early-RETURNS on a
+            # definitive signal, so it cannot loop.
+            deadline = time.monotonic() * 1000.0 + window_ms
+            solved = False
+            widget_gone = 0
+            _verdict_t0 = time.perf_counter()
+            while time.monotonic() * 1000.0 < deadline:
+                if self.is_captcha_solved(page):
+                    solved = True
+                    break
+                # The eight inline vendors have no response token, so
+                # `is_captcha_solved` — which reads only the hCaptcha and
+                # reCAPTCHA anchors — can never fire for them and this loop
+                # ran out its whole 2.5s budget on EVERY round, waiting for
+                # a signal that cannot arrive. Measured on geetest_v4_slide:
+                # 5.2s of a 12.3s solve, spent after the puzzle was already
+                # answered, with the widget sitting there visibly solved.
+                #
+                # "The widget is gone" is the completion signal for those
+                # vendors and is already the authority immediately after
+                # this loop, so this only reaches the same verdict sooner —
+                # confirmed over two polls so a frame caught mid-swap
+                # between rounds cannot read as a solve.
+                if self.detect_captcha(page) is None:
+                    widget_gone += 1
+                    if widget_gone >= 2:
                         solved = True
                         break
-                    # The eight inline vendors have no response token, so
-                    # `is_captcha_solved` — which reads only the hCaptcha and
-                    # reCAPTCHA anchors — can never fire for them and this loop
-                    # ran out its whole 2.5s budget on EVERY round, waiting for
-                    # a signal that cannot arrive. Measured on geetest_v4_slide:
-                    # 5.2s of a 12.3s solve, spent after the puzzle was already
-                    # answered, with the widget sitting there visibly solved.
-                    #
-                    # "The widget is gone" is the completion signal for those
-                    # vendors and is already the authority immediately after
-                    # this loop, so this only reaches the same verdict sooner —
-                    # confirmed over two polls so a frame caught mid-swap
-                    # between rounds cannot read as a solve.
-                    if self.detect_captcha(page) is None:
-                        widget_gone += 1
-                        if widget_gone >= 2:
-                            solved = True
-                            break
-                    else:
-                        widget_gone = 0
-                    if self._is_challenge_freshly_rendered(page):
-                        break  # next round is up; go solve it now
-                    _delay(cfg.post_solve_outcome_poll_ms)
-                _verdict_ms = (time.perf_counter() - _verdict_t0) * 1000.0
-                if self._budget is not None:
-                    self._budget.add("await-verdict", _verdict_ms)
-                # How long a SUCCESS actually took to show itself. This is the
-                # only number that can size `post_solve_outcome_timeout_ms`: the
-                # window exists to catch a late success, so it needs to cover
-                # the slowest real one and nothing beyond it. A round that ends
-                # any other way spends the whole window by construction — there
-                # is no signal on a wrong answer — so its duration says nothing
-                # about how long the window ought to be.
-                if solved:
-                    _log(f"[verdict] success signal arrived after {_verdict_ms:.0f}ms")
-                if solved:
-                    return SolveResult(True, self._last_mouse, _aggregate(cumulative_usage))
-            else:
-                with self._phase("post-submit-delay"):
-                    _delay(cfg.post_solve_delay_ms + random.random() * 300)
+                else:
+                    widget_gone = 0
+                if self._is_challenge_freshly_rendered(page):
+                    break  # next round is up; go solve it now
+                _delay(cfg.post_solve_outcome_poll_ms)
+            _verdict_ms = (time.perf_counter() - _verdict_t0) * 1000.0
+            if self._budget is not None:
+                self._budget.add(
+                    "await-verdict" if did_interact else "post-submit-delay",
+                    _verdict_ms)
+            # How long a SUCCESS actually took to show itself. This is the
+            # only number that can size `post_solve_outcome_timeout_ms`: the
+            # window exists to catch a late success, so it needs to cover
+            # the slowest real one and nothing beyond it. A round that ends
+            # any other way spends the whole window by construction — there
+            # is no signal on a wrong answer — so its duration says nothing
+            # about how long the window ought to be.
+            if solved:
+                _log(f"[verdict] success signal arrived after {_verdict_ms:.0f}ms")
+            if solved:
+                return SolveResult(True, self._last_mouse, _aggregate(cumulative_usage))
 
             if self._has_recaptcha_underselect_error(page):
                 if already_retried_underselect:

--- a/python/src/captchakraken/planner.py
+++ b/python/src/captchakraken/planner.py
@@ -312,6 +312,16 @@ class ActionPlanner:
         # Auto-start a local vLLM server on the first request if one isn't up
         # (no-op for a healthy or remote endpoint). Guarded so we only try once.
         self._server_ensured = False
+        # ONE connection, reused for every round of every solve this planner
+        # serves. `requests.post` opens a fresh TCP connection each call — and
+        # to a hosted endpoint a TLS handshake with it. Measured against the
+        # gate's own endpoint: 258ms per request connectionless vs 144ms
+        # pooled, so every inference was paying ~110ms to re-dial a server it
+        # had just finished talking to. A multi-round grid pays it per round.
+        #
+        # The planner is per-PageSolver and a PageSolver is reusable across
+        # solves, so a caller who keeps one keeps the connection warm too.
+        self._http = requests.Session()
 
     def _log(self, message: str) -> None:
         if DEBUG:
@@ -391,7 +401,7 @@ class ActionPlanner:
                   f"images={len(parts)}")
 
         with timed("planner.chat"):
-            resp = requests.post(url, headers=headers, json=payload, timeout=120)
+            resp = self._http.post(url, headers=headers, json=payload, timeout=120)
 
         # Surface auth / billing / server errors as something the reader can act
         # on, instead of letting resp.json() blow up with a cryptic "Expecting

--- a/python/src/captchakraken/server_manager.py
+++ b/python/src/captchakraken/server_manager.py
@@ -170,11 +170,16 @@ def ensure_server(base_url: "str | None" = None) -> None:
     """
     base_url = base_url or config.base_url()
 
-    if is_healthy(base_url):
-        return
+    # REMOTE FIRST. There is nothing to ensure about a server we do not manage,
+    # so asking it for /health before deciding that is a round trip spent to
+    # reach a `return` — and up to `timeout=2.0` of it against a hosted gateway
+    # that serves no /health at all. Paid once per ActionPlanner, which for a
+    # caller using `solve_captcha_on_page` is once per solve.
     if not is_local(base_url):
-        # Remote server we don't manage: let the actual request raise a clear
-        # connection error rather than silently trying to boot vLLM locally.
+        # Let the actual request raise a clear connection error rather than
+        # silently trying to boot vLLM locally.
+        return
+    if is_healthy(base_url):
         return
     if not config.autostart_enabled():
         return

--- a/python/src/captchakraken/timing.py
+++ b/python/src/captchakraken/timing.py
@@ -56,9 +56,14 @@ class PhaseBudget:
     monitor spent 31s of it" is. Always on — it is a few dict updates per phase
     against multi-second waits — but only PRINTED under CAPTCHA_TIMINGS=1.
 
-    Phases may nest (a burst contains its screenshots); only the outermost of a
-    given name accumulates, so the totals stay a partition of the solve rather
-    than double-counting.
+    Phases may nest (a burst contains its screenshots). Only the outermost of a
+    GIVEN NAME accumulates, so re-entering one cannot double-count it — but a
+    phase nested inside a differently-named one counts under both, deliberately:
+    the cursor drifting over the widget WHILE the model generates is genuinely
+    both `mouse` and `inference`, and hiding either would misreport what the
+    solve was doing. The totals are therefore an attribution, not a partition,
+    and can exceed the elapsed time. `report()` prints the residual as
+    `(unattributed)` and it can go negative when they do.
     """
 
     def __init__(self) -> None:

--- a/python/tests/test_endpoint_is_dialled_once.py
+++ b/python/tests/test_endpoint_is_dialled_once.py
@@ -1,0 +1,85 @@
+"""Two round trips per solve that bought nothing.
+
+1. NO CONNECTION WAS EVER REUSED. Every inference went through a bare
+   `requests.post`, which opens a new TCP connection — and, to a hosted HTTPS
+   endpoint, does a new TLS handshake on top. Measured against this project's
+   own endpoint, 8 requests each way:
+
+       fresh connection   p50 258ms
+       pooled reuse       p50 144ms
+
+   ~110ms per inference, paid again on every round of a multi-round grid, for
+   a server the process had finished talking to a second earlier.
+
+2. `ensure_server` ASKED A REMOTE SERVER FOR /health BEFORE DECIDING IT WAS
+   REMOTE. The function's whole job is to boot a LOCAL vLLM if one is not up;
+   for an endpoint we do not manage there is nothing to ensure and the very
+   next line returns. So the health GET was a round trip spent to reach a
+   `return` — and up to its 2s timeout against a hosted gateway that serves no
+   /health at all. Paid once per ActionPlanner, which for a caller using
+   `solve_captcha_on_page` is once per solve.
+
+Neither could show up as a failure: both are latency on a path that works.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from captchakraken import server_manager  # noqa: E402
+from captchakraken.planner import ActionPlanner  # noqa: E402
+
+
+def _planner() -> ActionPlanner:
+    return ActionPlanner(model="captcha", base_url="http://127.0.0.1:9/v1", api_key="k")
+
+
+def test_the_planner_holds_one_session_for_every_request():
+    assert isinstance(_planner()._http, requests.Session), (
+        "the planner has no connection pool, so every inference re-dials the "
+        "endpoint — ~110ms each, measured, and a TLS handshake against a "
+        "hosted one")
+
+
+def test_the_planner_never_posts_outside_that_session():
+    """The pool is inert if one call site still uses the module function."""
+    source = (Path(__file__).resolve().parents[1]
+              / "src" / "captchakraken" / "planner.py").read_text()
+    assert "requests.post(" not in source, (
+        "planner.py still calls requests.post directly; that call opens its own "
+        "connection and ignores the session")
+
+
+def test_a_remote_endpoint_is_not_health_checked(monkeypatch):
+    called = []
+    monkeypatch.setattr(server_manager, "is_healthy",
+                        lambda *a, **k: called.append(a) or True)
+    server_manager.ensure_server("http://13.57.41.42:8000/v1")
+    assert called == [], (
+        "ensure_server probed /health on a REMOTE endpoint. There is nothing to "
+        "ensure there — the next line returns — so that is a round trip, or a "
+        "2s timeout against a gateway that serves no /health, on every solve")
+
+
+def test_a_local_endpoint_is_still_health_checked(monkeypatch):
+    """The guard against 'just return early'."""
+    called = []
+    monkeypatch.setattr(server_manager, "is_healthy",
+                        lambda *a, **k: called.append(a) or True)
+    server_manager.ensure_server("http://127.0.0.1:8000/v1")
+    assert called, "a local endpoint must still be probed — booting one is the job"
+
+
+@pytest.mark.parametrize("url", ["http://localhost:8000/v1", "http://[::1]:8000/v1"])
+def test_the_other_local_spellings_are_still_local(monkeypatch, url):
+    called = []
+    monkeypatch.setattr(server_manager, "is_healthy",
+                        lambda *a, **k: called.append(a) or True)
+    server_manager.ensure_server(url)
+    assert called, f"{url} is a local endpoint and must still be probed"

--- a/python/tests/test_grid_round_pays_once.py
+++ b/python/tests/test_grid_round_pays_once.py
@@ -1,0 +1,154 @@
+"""Two things the reCAPTCHA grid driver was paying for twice, or not at all.
+
+Both were found by reading the phase budget of a solve that succeeded, which is
+why neither had ever shown up as a failure:
+
+    [BUDGET] solve 5.9s — 0.7s useful (11%), 5.3s waiting
+    [BUDGET]   grid-load                1.50s  x2      <- paid twice
+    [BUDGET]   post-submit-delay        1.48s  x1      <- should not exist
+    [BUDGET] * mouse                    0.65s  x0.65
+
+1. THE VERIFY PRESS IS AN INTERACTION, and the grid driver never said so.
+
+   `_solve_recaptcha_grid` sets `performed_action` when it CLICKS A TILE. A
+   round that answers `done` — reCAPTCHA 3x3's `none_present` variation, where
+   nothing matches and the control reads SKIP, and equally any board the model
+   reads as already correct — clicks no tile, presses Verify, and returns
+   False.
+
+   The caller reads that False as "this round did nothing", which costs two
+   things:
+
+     - it takes the `else` branch and sleeps `post_solve_delay_ms` flat
+       (1200-1500ms) instead of POLLING for the vendor's verdict, which
+       measured 3-528ms on a success. ~1s of dead time on every such solve.
+     - if the widget has not finished tearing down by the time it looks, it
+       raises "captcha still detected but the solver performed no
+       interactions" — an outright failure on a correctly submitted answer.
+
+   This is the same bug `test_empty_answer_still_submits.py` pins in
+   `_solve_single`, in the other driver. That one was fixed and this one was
+   not, because the two drivers were fixed on different days.
+
+2. THE GRID-LOAD WAIT WAS PAID TWICE, BACK TO BACK.
+
+   `_solve_single` waits for the cells to load, reads the grid boxes, sees a
+   3x3 and hands over to `_solve_recaptcha_grid` — whose round 1 opens by
+   waiting for the cells to load again, on a board that has not been touched
+   since. Measured 2148ms x2 on one solve. Rounds 2..N still wait, because by
+   then this driver has clicked tiles and the board really is reloading.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# The fakes: a PageSolver with everything around the grid driver stubbed out.
+# Imported rather than copied — they are 130 lines and there must be one
+# description of what a fake reCAPTCHA board does.
+from test_recaptcha_chipped_board import (  # noqa: E402
+    CELL_5,
+    CLICK_5,
+    DONE,
+    ELEMENT_BOX,
+    GRID_ARG,
+    _driver,
+    _FakeElement,
+    _FakePage,
+)
+
+#: A board that ticked our click and kept the photo — nothing to wait for.
+CHIPPED = {"empty": [], "changing": [5], "loaded": [1, 2, 3, 4, 6, 7, 8, 9], "selected": [5]}
+#: A board that blanked the clicked cell on its way to a replacement.
+SWAPPING = {"empty": [5], "changing": [], "loaded": [1, 2, 3, 4, 6, 7, 8, 9], "selected": []}
+
+
+def _counting_driver(states: Any, answers: List[Dict[str, Any]]):
+    """`_driver`, plus a count of how many times the grid-load wait was paid."""
+    solver, log = _driver(states, answers)
+    log["grid_loads"] = 0
+
+    def wait(_element: Any) -> bool:
+        log["grid_loads"] += 1
+        return True
+
+    solver._wait_for_grid_cells_loaded = wait  # type: ignore[method-assign]
+    return solver, log
+
+
+def _solve(solver: Any):
+    return solver._solve_recaptcha_grid(
+        _FakePage(), _FakeElement(), None, GRID_ARG, dict(ELEMENT_BOX)
+    )
+
+
+# ── 1. the submit ──────────────────────────────────────────────────────────
+
+def test_a_round_that_only_presses_verify_still_reports_an_interaction():
+    """`done` on round 1: no tile clicked, Verify pressed, answer submitted."""
+    solver, log = _counting_driver(CHIPPED, [DONE])
+    performed, _ = _solve(solver)
+
+    assert log["clicked"] == [], "the model said `done`; nothing should be clicked"
+    assert log["submits"] == 1, "a `done` answer is submitted by pressing Verify"
+    assert performed is True, (
+        "the driver pressed Verify and reported that it did nothing. The caller "
+        "then sleeps post_solve_delay_ms instead of polling for the verdict "
+        "(~1s of dead time), and raises 'performed no interactions' if the "
+        "widget has not vanished yet — on an answer that was correctly sent."
+    )
+
+
+def test_a_round_that_clicks_and_submits_still_reports_an_interaction():
+    """The case that already worked, kept so the fix cannot be a blanket True."""
+    solver, log = _counting_driver(CHIPPED, [CLICK_5, DONE])
+    performed, _ = _solve(solver)
+
+    assert log["clicked"] == [CELL_5]
+    assert performed is True
+
+
+def test_a_round_cap_exit_reports_no_interaction():
+    """The guard against 'just return True'.
+
+    A board that keeps answering `wait` never submits and never clicks, so it
+    genuinely did nothing — and the caller's infinite-loop guard is the only
+    thing that ends it. Reporting an interaction there would re-arm a solve
+    that cannot progress.
+    """
+    solver, log = _counting_driver(SWAPPING, [{"action": "wait"}])
+    performed, _ = _solve(solver)
+
+    assert log["submits"] == 0, "nothing was answered, so nothing may be submitted"
+    assert performed is False
+
+
+# ── 2. the wait ────────────────────────────────────────────────────────────
+
+def test_round_one_inherits_the_callers_grid_load_wait():
+    """One round, one wait — and round 1's was already paid by `_solve_single`.
+
+    That caller waits for the cells, reads the grid boxes off the loaded board
+    and only then hands over here. Waiting again is a poll interval and two
+    screenshots spent re-establishing something nothing has changed since.
+    """
+    solver, log = _counting_driver(CHIPPED, [DONE])
+    _solve(solver)
+
+    assert log["grid_loads"] == 0, (
+        f"round 1 waited for the grid to load {log['grid_loads']} time(s); the "
+        f"caller has just done exactly that and nothing has touched the board "
+        f"in between"
+    )
+
+
+def test_later_rounds_still_wait_for_the_board_they_changed():
+    """Rounds 2..N must keep waiting — they clicked, so tiles ARE reloading."""
+    solver, log = _counting_driver(SWAPPING, [CLICK_5, DONE])
+    _solve(solver)
+
+    assert log["rounds"] == 2, "a replaced tile has to be read once it lands"
+    assert log["grid_loads"] == 1, (
+        "round 2 opens on a board this driver has just clicked, so it must wait "
+        "for the replacement to paint before the model reads it"
+    )

--- a/python/tests/test_min_pixels_upscale.py
+++ b/python/tests/test_min_pixels_upscale.py
@@ -53,11 +53,16 @@ def captured(monkeypatch):
     """Send one request, hand back the payload instead of doing any I/O."""
     seen = {}
 
-    def fake_post(url, headers=None, json=None, timeout=None):
+    def fake_post(self, url, headers=None, json=None, timeout=None):
         seen["payload"] = json
         return _Resp()
 
-    monkeypatch.setattr(P.requests, "post", fake_post)
+    # The planner posts through its OWN pooled session, not the module
+    # function — one connection reused for every round of every solve, because
+    # re-dialling the endpoint measured 258ms against 144ms pooled. Patching
+    # `requests.post` here would leave the real socket in play and this test
+    # would reach the network.
+    monkeypatch.setattr(P.requests.Session, "post", fake_post)
     monkeypatch.setattr(P, "ensure_server", lambda *a, **k: None)
     return seen
 


### PR DESCRIPTION
Every change here came out of `SolveResult.phases` — a per-phase decomposition
the Python driver already kept and printed to stderr, which nothing could read
from outside the process. Both ports now return it, and the JS port gets the
budget at all (`timing.ts` mirrors `timing.py`).

The first thing it said, on a **successful** `recaptcha_grid_3x3`:

    [BUDGET] solve 5.9s — 0.7s useful (11%), 5.3s waiting
    [BUDGET]   grid-load                1.50s  x2      <- paid twice
    [BUDGET]   post-submit-delay        1.48s  x1      <- should not exist

None of these was ever visible as a failure. They are latency on paths that work.

## What changed

**Both ports**
- **The Verify press is an interaction.** The reCAPTCHA grid driver set
  `performed_action` when it clicked a TILE, so a round that answers `done`
  pressed Verify and reported having done nothing — the caller then took the
  no-interaction wait instead of polling for the verdict, and raised "performed
  no interactions" if the widget outlived it. Same bug `empty-answer-submits`
  pins in the other driver.
- **The grid-load wait was paid twice**, back to back, on a board nothing had
  touched in between (2148ms x2, measured).
- **One wait after a round, polled.** The no-interaction path slept 1200-1500ms
  flat and only then asked whether the widget was still there.
- **One travel to the submit control**, not two. It was resolved, moved to, and
  then moved to again by `moveAndClick`, which picks its own point inside it.
- **One connection.** Every inference re-dialled the endpoint: 258ms fresh vs
  144ms pooled, measured.
- **`ensure_server` asked a REMOTE server for /health** before deciding it was
  remote — a round trip to reach a `return`.

**JS only** (it measured ~4s slower per solve, and this is why)
- `scrollIntoViewIfNeeded()` **with no timeout**, once per action and once per
  submit. Playwright's default is 30s and it waits for the element to stop
  animating first. Python has bounded this at 2000ms for months.
- `emitStep()`'s observer snapshot used the MODEL's 8s screenshot budget, with
  animations disabled, so on an animated widget it waited the whole of it per
  step — 8.0s of a measured 12.0s solve.
- The **cursor drift during inference could not be interrupted**: it read its
  stop flag only between 180-540ms dwells, so every inference ended waiting out
  a pause with a click already queued.
- `resolveCli()` **re-probed the interpreter per inference** with a `spawnSync`
  that blocks the whole event loop; `resolveLoraName` re-read models.json beside
  it.
- **The widget going away is the success signal** for the eight vendors with no
  response token, and only Python knew it.

## What a reviewer should check

- Every fix has a regression test that was watched failing first. The two that
  are behavioural rather than structural — the interruptible drift and the
  bounded scroll — assert on the shape (an explicit timeout; an answer already
  available handed back before the opening pause) rather than on wall clock.
- **Humanisation is untouched.** No pause table, trajectory constant or gesture
  changed; `humanize.test.ts` and the cross-port parity tests are unchanged and
  green. The one movement change *removes* a second hop onto the same button,
  which is faster and is also not something a hand does.
- `post_solve_outcome_timeout_ms` (1000) and `max_solve_loops` x
  `overall_solve_timeout_ms` are untouched — both encode measured waits.
- `stepScreenshotTimeoutMs` is new public config; `SolveResult.phases` is a new
  optional field. Neither changes an existing deployment's behaviour.

`npm test` 138 pass / 0 fail; `python -m pytest` 460 pass / 15 skipped.
Driven end to end against the private fixture suite on both ports and both input
devices; the numbers are in the CaptchaKrakenFinetune PR.
---

**Measured end to end** against the private fixture suite, all 44 puzzle types,
both ports, both input devices, before and after, on the same box and endpoint
(under contention — treat the absolutes as upper bounds and the delta as the
result):

| | before | after |
|---|---|---|
| solve p50 | 6.8s | **5.1s** |
| solve p95 | 33.6s | **21.8s** |
| mean solve, Python port | 8.56s | **7.07s** |
| mean solve, Node port | 12.92s | **7.61s** |

The gap between the two ports closed from 4.36s to 0.54s. The fixture gate's
pass rate went **up**, from 84.1% to 90.9% of (puzzle type, port) pairs, with the
touch-input arm going from below its floor to above it. Details are in the
CaptchaKrakenFinetune PR.