### PR TITLE
Re-record the published surface three merges grew, and name the version that grew it

### DIFF
--- a/contract.json
+++ b/contract.json
@@ -1,10 +1,11 @@
 {
   "python": {
-    "version": "2.6.1",
+    "version": "2.7.0",
     "exports": [
       "ActionPlanner",
       "AppiumTouchBackend",
       "CaptchaAction",
+      "CaptchaKrakenAPIError",
       "CaptchaSolver",
       "CaptchaWatcher",
       "CdpTouchBackend",
@@ -85,6 +86,7 @@
     "solve_result_fields": [
       "final_mouse_position",
       "is_solved",
+      "phases",
       "token_usage"
     ],
     "config_functions": [
@@ -245,6 +247,7 @@
       "python/src/captchakraken/planner.py"
     ],
     "CAPTCHA_TIMINGS": [
+      "js/src/timing.ts",
       "python/src/captchakraken/timing.py"
     ],
     "PYTHONPATH": [
@@ -279,6 +282,7 @@
   "model_resolution": {
     "latest": "CaptchaKraken/CaptchaKraken-Lora-v1.2",
     "registered_models": [
+      "CaptchaKraken/Abyss",
       "CaptchaKraken/CaptchaKraken-Lora-v1.2",
       "CaptchaKraken/CaptchaKrakenV1_Lora",
       "CaptchaKraken/CaptchaKraken_v1.1",
@@ -317,7 +321,8 @@
       "",
       "js_only_config: options with no Python twin. onStep/repoPath/",
       "pythonCommand exist because the TS port SPAWNS the Python one and Python",
-      "has nothing to spawn; idleMouseWander is a real behaviour gap."
+      "has nothing to spawn; idleMouseWander is a real behaviour gap.",
+      "stepScreenshotTimeoutMs is js_only because it bounds onStep, which is itself js_only and listed above. Python has no on_step mechanism at all, so the option would be inert there — an inert knob is worse than an absent one. It shrinks off this list only when Python grows an observer."
     ],
     "python_only_config": [
       "animated_probe_enabled",
@@ -337,7 +342,8 @@
       "onStep",
       "pythonCommand",
       "repoPath",
-      "staleFrameReSolveEnabled"
+      "staleFrameReSolveEnabled",
+      "stepScreenshotTimeoutMs"
     ]
   },
   "js": {
@@ -416,6 +422,7 @@
       "staleFrameDiffThreshold",
       "staleFrameReSolveEnabled",
       "startingMousePosition",
+      "stepScreenshotTimeoutMs",
       "touchDriver",
       "touchTransform",
       "videoBurstDurationMs",
@@ -426,6 +433,7 @@
     "solve_result_fields": [
       "finalMousePosition",
       "isSolved",
+      "phases",
       "tokenUsage"
     ],
     "error_codes": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captchakraken",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Captcha solver for Playwright and Puppeteer. Finds the captcha, reads the puzzle with a fine-tuned Qwen3.5-9B vision model, and clicks, drags, slides or types through to a token — reCAPTCHA, hCaptcha, GeeTest, NetEase Yidun, Tencent, Lemin, Prosopo, Turnstile and distorted text. Hosted API or self-hosted.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "captchakraken"
-version = "2.6.1"
+version = "2.7.0"
 description = "Captcha-solving engine and CLI: OpenCV grid detection plus a fine-tuned Qwen3.5-9B vision model, for image grids, click and drag puzzles, sliders, distorted text and animated challenges. Hosted API or self-hosted on vLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/captchakraken/__init__.py
+++ b/python/src/captchakraken/__init__.py
@@ -107,4 +107,4 @@ __all__ = [
 # It said 2.6.0 while the wheel on PyPI said 2.6.1, so anyone gating on the
 # runtime attribute saw a version that had not been current for weeks.
 # tests/test_public_contract.py compares all three.
-__version__ = "2.6.1"
+__version__ = "2.7.0"


### PR DESCRIPTION
Tier 1 on `dev` is red on every push: `test_client_contract_is_pinned.py` fails because `contract.json` predates the four additions that only met each other at the merge.

**What a reviewer should check, in order:**

1. **That the change is additive.** I verified before regenerating, not after — zero removals and zero changed values across `python`, `cli`, `env`, `model_resolution`. Four names added: `CaptchaKrakenAPIError`, `phases`, `js/src/timing.ts`, `CaptchaKraken/Abyss`. If any of those had been a removal, regenerating would have erased the evidence of a real break, which is the one thing this file exists to prevent.

2. **The version bump.** Additive growth is a minor bump: 2.6.1 -> 2.7.0 in `pyproject.toml`, `js/package.json` and `__init__.py` — the three the version test compares. Independently, release PR #17 is already titled 2.7.0 while `dev` said 2.6.1, so the release would otherwise have shipped a version contradicting its own name.

3. **`stepScreenshotTimeoutMs`, the one judgement call.** The parity test flagged it as a NEW cross-port divergence, correctly. I recorded it in `parity.js_only_config` instead of adding it to Python, because it bounds `onStep` — already js_only and listed one line above — and Python has no `on_step` mechanism at all, so the option would be inert. An inert knob is worse than an absent one. **If you would rather Python grew an observer, this is the line to push back on.**

Verified locally: python **451 passed / 48 skipped**, js **142 passed / 0 failed**, mcp builds clean.