### PR TITLE
Drop the video line: it is true of every model we list

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captchakraken-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP server for the CaptchaKraken account: sign in with GitHub, mint and revoke API keys for the captcha-solving endpoint, and read your usage and balance. Writes the key to disk so the solver needs no environment variables.",
   "type": "module",
   "author": "Jake Writer",

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -176,7 +176,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export function createServer(baseUrl: string, clientName: string): McpServer {
   const api = new ControlPlane(baseUrl);
   const server = new McpServer(
-    { name: 'captchakraken', version: '0.1.3' },
+    { name: 'captchakraken', version: '0.1.4' },
     {
       instructions:
         'CaptchaKraken account management. Use sign_in once to connect a GitHub account, ' +
@@ -764,7 +764,15 @@ export function createServer(baseUrl: string, clientName: string): McpServer {
           if (model.accuracy !== null) {
             lines.push(`  Measured: ${(model.accuracy * 100).toFixed(1)}% exact match`);
           }
-          if (model.video) lines.push('  Handles video challenges.');
+          // NO VIDEO LINE. Animated support is a property of the GENERATION:
+          // every v1.2 model answers animated challenges and no v1 or v1.1 model
+          // can. The whole lineup is v1.2, so this printed on all three — which
+          // tells an agent choosing between them nothing, and implies the ones
+          // it is missing from cannot. It was worse than uninformative until
+          // 2026-09-06, when the control plane had Sunlight flagged `false` and
+          // this line said the 4-bit merge could not do video. The field is
+          // still published by `/api/v1/models`; it just is not worth a line
+          // while it is true of everything.
           lines.push('');
         }
         return text(lines.join('\n').trimEnd());


### PR DESCRIPTION
Animated support is a property of the GENERATION. Every v1.2 model answers
animated challenges and no v1 or v1.1 model can — the older ones were never
trained on a keyframe prompt. The whole lineup is v1.2, so this printed on all
three, which tells an agent choosing between them nothing and implies the ones
it is missing from cannot.

It was worse than uninformative until today: the control plane had Sunlight
flagged `false`, so an agent asking what to self-host was told the 4-bit merge
could not do video. It can — it is the same adapter as Twilight, merged down
further, and quantisation costs precision rather than a prompt family. That data
is fixed in captchakraken-cloud; this removes the line that was reporting it.

The field is still published by `/api/v1/models` and still read here — it just
does not earn a line while it is true of everything. contract.json is unchanged:
this is output text, not a tool signature.

0.1.4. Smoke passes, 11 tools, contract matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LWYo3k7t677i4z1WdsUkE