### PR TITLE
Re-ask when an animated answer is refused

### DIFF
--- a/js/src/no-progress.test.ts
+++ b/js/src/no-progress.test.ts
@@ -111,3 +111,56 @@ test('the budget fits the loop count', () => {
     `${maxSolveLoops} rounds x 7000ms exceeds the ${overallSolveTimeoutMs}ms cap`,
   );
 });
+
+/*
+ * A CACHED ANIMATED ANSWER MUST NOT OUTLIVE ITS REFUSAL.
+ *
+ * `animatedPlan` holds one burst and one inference for as long as a board is on
+ * screen, which is right while the answer is merely untested: the frames do not
+ * change, so re-recording buys nothing. Once the widget has refused the answer
+ * it is wrong, because re-submitting identical coordinates cannot succeed — and
+ * the escalation above raises the SAMPLE, which never reaches the wire while a
+ * cached response stands in front of it.
+ *
+ * The rule is therefore two-part and both halves matter: drop the answer, keep
+ * the frames. Dropping both would spend another `videoBurstMaxMs` filming
+ * screens already in hand.
+ *
+ * Mirrors `_invalidate_animated_answer` in the Python port. Both ports drive the
+ * same fixtures under Tier 3 and must behave identically.
+ */
+test('a repeat drops the cached animated answer but keeps the frames', () => {
+  const s = solver();
+  s.animatedPlan = { burstDir: '/tmp/burst-abc', response: { actions: [] } };
+
+  s.noteAnswer(click([0.1, 0.1, 0.2, 0.2]), null);
+  s.noteAnswer(click([0.1, 0.1, 0.2, 0.2]), null);
+
+  assert.equal(s.animatedPlan.response, null, 'the refused answer must not be re-served');
+  assert.equal(s.animatedPlan.burstDir, '/tmp/burst-abc', 'the frames are still good');
+});
+
+test('an answer that is still making progress keeps its recording', () => {
+  // Invalidating on every round would re-ask once per round on a board that is
+  // being solved correctly, which is one inference per round of pure cost.
+  const s = solver();
+  const plan = { burstDir: '/tmp/burst-abc', response: { actions: [] } };
+  s.animatedPlan = plan;
+
+  s.noteAnswer(click([0.1, 0.1, 0.2, 0.2]), null);
+  s.noteAnswer(click([0.5, 0.5, 0.6, 0.6]), null);
+
+  assert.equal(s.animatedPlan.response, plan.response, 'a changing answer is not a refusal');
+});
+
+test('invalidating twice is not an error', () => {
+  // The no-progress path can fire again before the next round reaches a
+  // request; the second call must be a no-op rather than clearing the frames.
+  const s = solver();
+  s.animatedPlan = { burstDir: '/tmp/burst-abc', response: { actions: [] } };
+  s.invalidateAnimatedAnswer();
+  s.invalidateAnimatedAnswer();
+
+  assert.equal(s.animatedPlan.response, null);
+  assert.equal(s.animatedPlan.burstDir, '/tmp/burst-abc');
+});

--- a/js/src/solver.ts
+++ b/js/src/solver.ts
@@ -515,7 +515,10 @@ export class CaptchaKrakenSolver {
    * the widget is no longer the board this plan was made for, which is exactly
    * when a fresh recording is warranted.
    */
-  private animatedPlan: { burstDir: string; response: CliResponse } | null = null;
+  // `response` is nullable so a REFUSED answer can be dropped while the
+  // frames are kept: re-asking then costs one inference rather than another
+  // burst. See `invalidateAnimatedAnswer`.
+  private animatedPlan: { burstDir: string; response: CliResponse | null } | null = null;
   // Slicing mode of the burst the current answer came from, as reported by
   // `solve-animated`. `waitForKeyframe` reads it: `even` means the slicer found
   // no state that RECURS, so there is nothing for the page to come back to and
@@ -1311,10 +1314,21 @@ export class CaptchaKrakenSolver {
       let response: CliResponse;
       if (isAnimated) {
         // ONE burst, ONE inference, for as long as this board is on screen.
-        if (this.animatedPlan) {
+        if (this.animatedPlan?.response) {
           burstDir = this.animatedPlan.burstDir;
           response = this.animatedPlan.response;
           console.log('[animated] reusing the recorded answer — same board, same screens');
+        } else if (this.animatedPlan) {
+          // The screens have not changed, so the recording still stands; only
+          // the ANSWER is gone. Re-ask on the frames already in hand.
+          burstDir = this.animatedPlan.burstDir;
+          console.log(
+            '[animated] same screens, but the last answer was refused — '
+            + 're-asking on the frames already recorded',
+          );
+          response = await this.ph('inference', () => this.withIdleWander(page, captchaElement, () =>
+            this.getAnimatedSolution(burstDir as string)));
+          this.animatedPlan = { burstDir, response };
         } else {
           burstDir = await this.ph('burst', () => this.recordKeyframeBurst(captchaElement));
           response = await this.ph('inference', () => this.withIdleWander(page, captchaElement, () =>
@@ -3525,6 +3539,26 @@ export class CaptchaKrakenSolver {
   }
 
   /** Count consecutive identical answers; see `maxNoProgressRounds`. */
+  /**
+   * The recording is still good; the ANSWER it produced is not.
+   *
+   * `animatedPlan` caches one burst and one inference for as long as a board is
+   * on screen. That is right for a cycling board whose answer merely landed on
+   * the wrong screen — the frames do not change, so re-recording buys nothing.
+   * It stops being right the moment the widget has REFUSED the answer:
+   * re-submitting identical coordinates cannot succeed, and a fresh sample
+   * cannot reach the wire while a cached response is standing in front of it.
+   *
+   * Drops the answer and keeps the frames, so the retry costs one inference
+   * rather than another `videoBurstMaxMs` of filming. Mirrors
+   * `_invalidate_animated_answer` in the python port.
+   */
+  private invalidateAnimatedAnswer(): void {
+    const plan = this.animatedPlan;
+    if (!plan || plan.response === null) return;
+    this.animatedPlan = { burstDir: plan.burstDir, response: null };
+  }
+
   private noteAnswer(actions: any[], retryMode: string | null): void {
     const sig = CaptchaKrakenSolver.answerSignature(actions, retryMode);
     if (sig !== null && sig === this.lastAnswerSig) {
@@ -3539,6 +3573,11 @@ export class CaptchaKrakenSolver {
       // identical answer by construction, and counting that to a limit
       // measures the limit. Ask for a different SAMPLE instead.
       this.resampleLevel++;
+      // …and make sure there is something to re-ask. On the animated path the
+      // answer is cached for the life of the board, so without this the new
+      // sampling never reaches a request and the identical coordinates go back
+      // up the wire.
+      this.invalidateAnimatedAnswer();
       // A board that reads the same every round is ALSO the signature of a
       // CYCLING challenge answered as a still. Let the recording path have a go
       // before giving up on the solve entirely.


### PR DESCRIPTION
`animatedPlan` holds one burst and one inference for as long as a board is on screen. That is right while the answer is untested — the frames do not change, so re-recording buys nothing — and wrong the moment the widget has refused it: re-submitting identical coordinates cannot succeed.

The no-progress path already raises the sampling level on a repeat, but a raised sample never reaches the wire while a cached response stands in front of it, so the same coordinates went back up round after round until the solve ran out of them.

The invariant is two-part and both halves matter: drop the ANSWER, keep the FRAMES. Dropping both would spend another `videoBurstMaxMs` filming screens already in hand; dropping neither is the loop above.

Measured against the fixtures, one animated board, three attempts per port. Keyframe calls per attempt went 1/1/1 to 1/1/3, matching the python port, which had 1/2/3 throughout.

Mirrors `_invalidate_animated_answer` in the python port; both drive the same fixtures and must behave identically.